### PR TITLE
Add basic ETL file support and fix a bunch of bugs, especially focusing around the CSVs.

### DIFF
--- a/PresentMon.cpp
+++ b/PresentMon.cpp
@@ -94,11 +94,8 @@ const char* RuntimeToString(Runtime rt)
 }
 
 void PruneDeque(std::deque<PresentEvent> &presentHistory, uint64_t perfFreq, uint32_t msTimeDiff) {
-    LARGE_INTEGER now;
-    QueryPerformanceCounter(&now);
-
     while (!presentHistory.empty() &&
-           ((double)(now.QuadPart - presentHistory.front().QpcTime) / perfFreq) * 1000 > msTimeDiff) {
+           ((double)(presentHistory.back().QpcTime - presentHistory.front().QpcTime) / perfFreq) * 1000 > msTimeDiff) {
         presentHistory.pop_front();
     }
 

--- a/PresentMon.hpp
+++ b/PresentMon.hpp
@@ -74,6 +74,7 @@ struct PresentEvent {
     uint32_t QueueSubmitSequence = 0;
     uint64_t Hwnd = 0;
     std::deque<std::shared_ptr<PresentEvent>> DependentPresents;
+    bool MMIO = false;
 #if _DEBUG
     bool Completed = false;
     ~PresentEvent() { assert(Completed || g_Quit); }

--- a/PresentMon.hpp
+++ b/PresentMon.hpp
@@ -99,7 +99,9 @@ struct ProcessInfo {
 struct PresentMonArgs {
     const char *mOutputFileName = nullptr;
     const char *mTargetProcessName = nullptr;
+    const char *mEtlFileName = nullptr;
     int mTargetPid = 0;
+    bool mInputOnly = false;
 };
 
 struct PresentMonData {

--- a/PresentMonEtw.cpp
+++ b/PresentMonEtw.cpp
@@ -607,7 +607,9 @@ void DxgiConsumer::OnDXGKrnlEvent(PEVENT_RECORD pEventRecord)
             }
 
             if (eventIter->second->TimeTaken != 0 || eventIter->second->Runtime == Runtime::Other) {
-                eventIter->second->TimeTaken = EventTime - eventIter->second->QpcTime;
+                if (eventIter->second->TimeTaken == 0) {
+                    eventIter->second->TimeTaken = EventTime - eventIter->second->QpcTime;
+                }
                 mPresentByThreadId.erase(eventIter);
             }
             break;

--- a/TraceSession.cpp
+++ b/TraceSession.cpp
@@ -16,14 +16,16 @@ static ULONG WINAPI BufferRecordCallback(_In_ PEVENT_TRACE_LOGFILE Buffer)
     return reinterpret_cast<ITraceConsumer *>(Buffer->Context)->ContinueProcessing();
 }
 
-TraceSession::TraceSession(LPCTSTR szSessionName) 
+TraceSession::TraceSession(LPCTSTR szSessionName, LPCTSTR szFileName) 
     : _szSessionName(_tcsdup(szSessionName))
+    , _szFileName(_tcsdup(szFileName))
     , _status(0)
     , _pSessionProperties(0)
     , hSession(0)
     , _hTrace(0)
     , _eventsLost(0)
     , _buffersLost(0)
+    , _started(false)
 {
 }
 
@@ -37,7 +39,8 @@ bool TraceSession::Start()
 {
     if (!_pSessionProperties) {
         static_assert(sizeof(EVENT_TRACE_PROPERTIES) == 120, "");
-        const ULONG buffSize = sizeof(EVENT_TRACE_PROPERTIES) + (ULONG)(_tcslen(_szSessionName) + 1) * sizeof(TCHAR);
+        const ULONG buffSize = sizeof(EVENT_TRACE_PROPERTIES) + (ULONG)(_tcslen(_szSessionName) + 1) * sizeof(TCHAR) +
+            (_szFileName ? (ULONG)(_tcslen(_szFileName) + 1) * sizeof(TCHAR) : 0);
         _pSessionProperties = reinterpret_cast<EVENT_TRACE_PROPERTIES *>(malloc(buffSize));
         ZeroMemory(_pSessionProperties, buffSize);
         _pSessionProperties->Wnode.BufferSize = buffSize;
@@ -47,17 +50,29 @@ bool TraceSession::Start()
         _pSessionProperties->BufferSize = 0;
         _pSessionProperties->MaximumBuffers = 100;
         _pSessionProperties->MaximumBuffers = 200;
+
+        if (_szFileName)
+        {
+            _pSessionProperties->LogFileNameOffset =
+                _pSessionProperties->LoggerNameOffset + (ULONG)(_tcslen(_szSessionName) + 1) * sizeof(TCHAR);
+            wchar_t* dest = reinterpret_cast<wchar_t*>(reinterpret_cast<char*>(_pSessionProperties) + _pSessionProperties->LogFileNameOffset);
+            wcscpy(dest, _szFileName);
+        }
     }
 
     // Create the trace session.
     _status = StartTraceW(&hSession, _szSessionName, _pSessionProperties);
+    _started = (_status == ERROR_SUCCESS);
 
-    return (_status == ERROR_SUCCESS);
+    return _started;
 }
 
 bool TraceSession::EnableProvider(const GUID& providerId, UCHAR level, ULONGLONG anyKeyword, ULONGLONG allKeyword)
 {
-    _status = EnableTraceEx2(hSession, &providerId, EVENT_CONTROL_CODE_ENABLE_PROVIDER, level, anyKeyword, allKeyword, 0, NULL);
+    if (_started)
+    {
+        _status = EnableTraceEx2(hSession, &providerId, EVENT_CONTROL_CODE_ENABLE_PROVIDER, level, anyKeyword, allKeyword, 0, NULL);
+    }
     return (_status == ERROR_SUCCESS);
 }
 
@@ -67,14 +82,22 @@ bool TraceSession::OpenTrace(ITraceConsumer *pConsumer)
         return false;
 
     ZeroMemory(&_logFile, sizeof(EVENT_TRACE_LOGFILE));
-    _logFile.LoggerName = _szSessionName;
-    _logFile.ProcessTraceMode = PROCESS_TRACE_MODE_REAL_TIME | PROCESS_TRACE_MODE_EVENT_RECORD | PROCESS_TRACE_MODE_RAW_TIMESTAMP;
+    if (_started)
+    {
+        _logFile.LoggerName = _szSessionName;
+        _logFile.ProcessTraceMode = PROCESS_TRACE_MODE_REAL_TIME;
+    }
+    else
+    {
+        _logFile.LogFileName = _szFileName;
+    }
+    _logFile.ProcessTraceMode |= PROCESS_TRACE_MODE_EVENT_RECORD | PROCESS_TRACE_MODE_RAW_TIMESTAMP;
     _logFile.EventRecordCallback = &EventRecordCallback;
     _logFile.BufferCallback = &BufferRecordCallback;
     _logFile.Context = pConsumer;
 
     _hTrace = ::OpenTraceW(&_logFile);
-    return (_hTrace != 0);
+    return (_hTrace != (TRACEHANDLE)INVALID_HANDLE_VALUE);
 }
 
 bool TraceSession::Process()
@@ -91,30 +114,45 @@ bool TraceSession::CloseTrace()
 
 bool TraceSession::DisableProvider(const GUID& providerId)
 {
-    _status = EnableTraceEx2(hSession, &providerId, EVENT_CONTROL_CODE_DISABLE_PROVIDER, 0, 0, 0, 0, NULL);
+    if (_started)
+    {
+        _status = EnableTraceEx2(hSession, &providerId, EVENT_CONTROL_CODE_DISABLE_PROVIDER, 0, 0, 0, 0, NULL);
+    }
     return (_status == ERROR_SUCCESS);
 }
 
 bool TraceSession::Stop()
 {
-    _status = ControlTraceW(hSession, _szSessionName, _pSessionProperties, EVENT_TRACE_CONTROL_STOP);
-    delete _pSessionProperties;
-    _pSessionProperties = NULL;
+    if (_pSessionProperties)
+    {
+        _status = ControlTraceW(hSession, _szSessionName, _pSessionProperties, EVENT_TRACE_CONTROL_STOP);
+        delete _pSessionProperties;
+        _pSessionProperties = NULL;
+        _started = false;
+    }
 
     return (_status == ERROR_SUCCESS);
 }
 
 bool TraceSession::AnythingLost(uint32_t &events, uint32_t &buffers)
 {
-    _status = ControlTraceW(hSession, _szSessionName, _pSessionProperties, EVENT_TRACE_CONTROL_QUERY);
-    if (_status != ERROR_SUCCESS && _status != ERROR_MORE_DATA) {
-        return true;
+    if (_started)
+    {
+        _status = ControlTraceW(hSession, _szSessionName, _pSessionProperties, EVENT_TRACE_CONTROL_QUERY);
+        if (_status != ERROR_SUCCESS && _status != ERROR_MORE_DATA) {
+            return true;
+        }
+        _status = ERROR_SUCCESS;
+        events = _pSessionProperties->EventsLost - _eventsLost;
+        buffers = _pSessionProperties->RealTimeBuffersLost - _buffersLost;
+        _eventsLost = _pSessionProperties->EventsLost;
+        _buffersLost = _pSessionProperties->RealTimeBuffersLost;
     }
-    _status = ERROR_SUCCESS;
-    events = _pSessionProperties->EventsLost - _eventsLost;
-    buffers = _pSessionProperties->RealTimeBuffersLost - _buffersLost;
-    _eventsLost = _pSessionProperties->EventsLost;
-    _buffersLost = _pSessionProperties->RealTimeBuffersLost;
+    else
+    {
+        events = 0;
+        buffers = 0;
+    }
     return events > 0 || buffers > 0;
 }
 

--- a/TraceSession.hpp
+++ b/TraceSession.hpp
@@ -21,7 +21,7 @@ class TraceSession
 {
 
 public:
-    TraceSession(LPCTSTR szSessionName);
+    TraceSession(LPCTSTR szSessionName, LPCTSTR szFileName);
     ~TraceSession();
 
 public:
@@ -39,11 +39,12 @@ public:
     LONGLONG PerfFreq() const;
 
 private:
-    LPTSTR _szSessionName;
+    LPTSTR _szSessionName, _szFileName;
     ULONG _status;
     EVENT_TRACE_PROPERTIES* _pSessionProperties;
     TRACEHANDLE hSession;
     EVENT_TRACE_LOGFILEW _logFile;
     TRACEHANDLE _hTrace;
     uint32_t _eventsLost, _buffersLost;
+    bool _started;
 };

--- a/main.cpp
+++ b/main.cpp
@@ -36,20 +36,25 @@ BOOL WINAPI HandlerRoutine(
     return TRUE;
 }
 
+void printHelp()
+{
+    printf(
+        "command line options:\n"
+        " -captureall: record ALL processes (default).\n"
+        " -process_name [exe name]: record specific process.\n"
+        " -process_id [integer]: record specific process ID.\n"
+        " -output_file [path]: override the default output path.\n"
+        " -no_csv: do not create any output file.\n"
+        );
+}
+
 int main(int argc, char ** argv)
 {
     --argc;
     ++argv;
 
     if (argc == 0) {
-        printf(
-            "command line options:\n"
-            " -captureall: record ALL processes (default).\n"
-            " -process_name [exe name]: record specific process.\n"
-            " -process_id [integer]: record specific process ID.\n"
-            " -output_file [path]: override the default output path.\n"
-            " -no_csv: do not create any output file.\n"
-            );
+        printHelp();
         return 0;
     }
 
@@ -81,12 +86,25 @@ int main(int argc, char ** argv)
             {
                 args.mOutputFileName = argv[++i];
             }
+            else if (!strcmp(argv[i], "-etl_file"))
+            {
+                args.mEtlFileName = argv[++i];
+            }
         }
         // 1-component args
         {
             if (!strcmp(argv[i], "-no_csv"))
             {
                 args.mOutputFileName = "*";
+            }
+            else if (!strcmp(argv[i], "-?") || !strcmp(argv[i], "-help"))
+            {
+                printHelp();
+                return 0;
+            }
+            else if (!strcmp(argv[i], "-input_etl"))
+            {
+                args.mInputOnly = true;
             }
         }
 
@@ -114,5 +132,9 @@ int main(int argc, char ** argv)
     // Run PM in a separate thread so we can join it in the CtrlHandler (can't join the main thread)
     std::thread pm(PresentMonEtw, args);
     g_PresentMonThread = &pm;
-    Sleep(INFINITE);
+    while (!g_Quit)
+    {
+        Sleep(100);
+    }
+    pm.join();
 }

--- a/main.cpp
+++ b/main.cpp
@@ -136,5 +136,5 @@ int main(int argc, char ** argv)
     {
         Sleep(100);
     }
-    pm.join();
+    exit(0);
 }


### PR DESCRIPTION
Adds support for writing to an ETL file in addition to the real-time monitoring, or alternatively parsing an already existing ETL file (e.g. converting from ETL to present list in CSV format). The real-time monitoring only works correctly when the processes in the ETL are still running, since it still uses real-time OpenProcess techniques to convert from the PID in the events to useful info.

There's several bugfixes here too. A primary focus was around ensuring events are written to the CSV in order, to prevent super large (negative) deltas. There are also some assertion cleanups, fixes to events being discarded when they shouldn't and not discarded when they should, and a rare double-completion issue which caused framerates and deltas to come up incorrect.