### PR TITLE
Polish up ETL file support, add some quality-of-life functionality, and more bugfixes

### DIFF
--- a/PresentMon.hpp
+++ b/PresentMon.hpp
@@ -102,7 +102,6 @@ struct PresentMonArgs {
     const char *mTargetProcessName = nullptr;
     const char *mEtlFileName = nullptr;
     int mTargetPid = 0;
-    bool mInputOnly = false;
 };
 
 struct PresentMonData {
@@ -114,6 +113,8 @@ struct PresentMonData {
 void PresentMonEtw(PresentMonArgs args);
 
 void PresentMon_Init(const PresentMonArgs& args, PresentMonData& data);
+void PresentMon_UpdateNewProcesses(PresentMonData& data, std::map<uint32_t, ProcessInfo>& processes);
 void PresentMon_Update(PresentMonData& data, std::vector<std::shared_ptr<PresentEvent>> presents, uint64_t perfFreq);
+void PresentMon_UpdateDeadProcesses(PresentMonData& data, std::vector<uint32_t>& processIds);
 void PresentMon_Shutdown(PresentMonData& data);
 

--- a/PresentMon.hpp
+++ b/PresentMon.hpp
@@ -102,6 +102,9 @@ struct PresentMonArgs {
     const char *mTargetProcessName = nullptr;
     const char *mEtlFileName = nullptr;
     int mTargetPid = 0;
+    int mDelay = 0;
+    int mTimer = 0;
+    bool mScrollLockToggle = false;
 };
 
 struct PresentMonData {

--- a/PresentMon.hpp
+++ b/PresentMon.hpp
@@ -29,16 +29,15 @@ extern bool g_Quit;
 enum class PresentMode
 {
     Unknown,
-    Fullscreen,
+    Hardware_Legacy_Flip,
+    Hardware_Legacy_Copy_To_Front_Buffer,
+    Hardware_Direct_Flip,
+    Hardware_Independent_Flip,
     Composed_Flip,
-    DirectFlip,
-    IndependentFlip,
-    ImmediateIndependentFlip,
-    IndependentFlipMPO,
-    Windowed_Blit,
-    Fullscreen_Blit,
-    Legacy_Windowed_Blit,
-    Composition_Buffer,
+    Composed_Copy_GPU_GDI,
+    Composed_Copy_CPU_GDI,
+    Composed_Composition_Atlas,
+    Hardware_Composed_Independent_Flip,
 };
 enum class PresentResult
 {
@@ -57,6 +56,9 @@ struct PresentEvent {
     uint32_t ProcessId = 0;
 
     PresentMode PresentMode = PresentMode::Unknown;
+    bool SupportsTearing = true;
+    bool MMIO = false;
+
     Runtime Runtime = Runtime::Other;
 
     // Time spent in DXGI Present call
@@ -74,7 +76,6 @@ struct PresentEvent {
     uint32_t QueueSubmitSequence = 0;
     uint64_t Hwnd = 0;
     std::deque<std::shared_ptr<PresentEvent>> DependentPresents;
-    bool MMIO = false;
 #if _DEBUG
     bool Completed = false;
     ~PresentEvent() { assert(Completed || g_Quit); }
@@ -89,6 +90,7 @@ struct SwapChainData {
     std::deque<PresentEvent> mPresentHistory;
     std::deque<PresentEvent> mDisplayedPresentHistory;
     PresentMode mLastPresentMode = PresentMode::Unknown;
+    uint32_t mLastPlane = 0;
 };
 
 struct ProcessInfo {

--- a/main.cpp
+++ b/main.cpp
@@ -46,8 +46,11 @@ void printHelp()
         " -process_name [exe name]: record specific process.\n"
         " -process_id [integer]: record specific process ID.\n"
         " -output_file [path]: override the default output path.\n"
+        " -etl_file [path]: consume events from an ETL file instead of real-time.\n"
+        " -delay [seconds]: wait before starting to consume events (allowing time for alt+tab)\n"
+        " -timed [seconds]: stop listening and exit after a set amount of time\n"
         " -no_csv: do not create any output file.\n"
-        " -etl_file: consume events from an ETL file instead of real-time.\n"
+        " -scroll_toggle: only record events while scroll lock is enabled.\n"
         );
 }
 
@@ -93,12 +96,24 @@ int main(int argc, char ** argv)
             {
                 args.mEtlFileName = argv[++i];
             }
+            else if (!strcmp(argv[i], "-delay"))
+            {
+                args.mDelay = atoi(argv[++i]);
+            }
+            else if (!strcmp(argv[i], "-timed"))
+            {
+                args.mTimer = atoi(argv[++i]);
+            }
         }
         // 1-component args
         {
             if (!strcmp(argv[i], "-no_csv"))
             {
                 args.mOutputFileName = "*";
+            }
+            else if (!strcmp(argv[i], "-scroll_toggle"))
+            {
+                args.mScrollLockToggle = true;
             }
             else if (!strcmp(argv[i], "-?") || !strcmp(argv[i], "-help"))
             {


### PR DESCRIPTION
Adds delayed startup, timed runs, logging only while scroll lock is active. Fixes issues related to exiting. Adds ability to get process info from ETL file instead of realtime APIs. Fix DWM presents getting lost on MPO systems (which also resulted in all blit model or composition buffer presents getting lost).