### PR TITLE
Some quality-of-life fixes for ETL file support

### DIFF
--- a/PresentMon.cpp
+++ b/PresentMon.cpp
@@ -218,7 +218,16 @@ void PresentMon_Init(const PresentMonArgs& args, PresentMonData& pm)
 {
     pm.mArgs = &args;
 
-    QueryPerformanceCounter((PLARGE_INTEGER)&pm.mStartupQpcTime);
+	if (!args.mEtlFileName)
+	{
+		QueryPerformanceCounter((PLARGE_INTEGER)&pm.mStartupQpcTime);
+	}
+	else
+	{
+		// Reading events from ETL file so current QPC value is irrelevant. Update this 
+		// later from first event in the file.
+		pm.mStartupQpcTime = 0;
+	}
 
     if (args.mOutputFileName) {
         pm.mOutputFilePath = args.mOutputFileName;

--- a/PresentMon.cpp
+++ b/PresentMon.cpp
@@ -218,16 +218,16 @@ void PresentMon_Init(const PresentMonArgs& args, PresentMonData& pm)
 {
     pm.mArgs = &args;
 
-	if (!args.mEtlFileName)
-	{
-		QueryPerformanceCounter((PLARGE_INTEGER)&pm.mStartupQpcTime);
-	}
-	else
-	{
-		// Reading events from ETL file so current QPC value is irrelevant. Update this 
-		// later from first event in the file.
-		pm.mStartupQpcTime = 0;
-	}
+    if (!args.mEtlFileName)
+    {
+        QueryPerformanceCounter((PLARGE_INTEGER)&pm.mStartupQpcTime);
+    }
+    else
+    {
+        // Reading events from ETL file so current QPC value is irrelevant. Update this 
+        // later from first event in the file.
+        pm.mStartupQpcTime = 0;
+    }
 
     if (args.mOutputFileName) {
         pm.mOutputFilePath = args.mOutputFileName;

--- a/PresentMonEtw.cpp
+++ b/PresentMonEtw.cpp
@@ -213,8 +213,8 @@ struct PMTraceConsumer : ITraceConsumer
     std::map<uint32_t, ProcessInfo> mNewProcessesFromETW;
     std::vector<uint32_t> mDeadProcessIds;
 
-	// Time of the first event of the trace
-	uint64_t mTraceStartTime = 0;
+    // Time of the first event of the trace
+    uint64_t mTraceStartTime = 0;
 
     bool DequeuePresents(std::vector<std::shared_ptr<PresentEvent>>& outPresents)
     {
@@ -1027,10 +1027,10 @@ void PMTraceConsumer::OnNTProcessEvent(PEVENT_RECORD pEventRecord)
 
 void PMTraceConsumer::OnEventRecord(PEVENT_RECORD pEventRecord)
 {
-	if (mTraceStartTime == 0)
-	{
-		mTraceStartTime = pEventRecord->EventHeader.TimeStamp.QuadPart;
-	}
+    if (mTraceStartTime == 0)
+    {
+        mTraceStartTime = pEventRecord->EventHeader.TimeStamp.QuadPart;
+    }
 
     auto& hdr = pEventRecord->EventHeader;
 
@@ -1124,11 +1124,11 @@ void PresentMonEtw(const PresentMonArgs& args)
                 newProcesses.clear();
                 deadProcesses.clear();
 
-				// If we are reading events from ETL file set start time to match time stamp of first event
-				if (data.mArgs->mEtlFileName && data.mStartupQpcTime == 0)
-				{
-					data.mStartupQpcTime = consumer.mTraceStartTime;
-				}
+                // If we are reading events from ETL file set start time to match time stamp of first event
+                if (data.mArgs->mEtlFileName && data.mStartupQpcTime == 0)
+                {
+                    data.mStartupQpcTime = consumer.mTraceStartTime;
+                }
 
                 if (args.mEtlFileName) {
                     consumer.GetProcessEvents(newProcesses, deadProcesses);

--- a/PresentMonEtw.cpp
+++ b/PresentMonEtw.cpp
@@ -213,6 +213,9 @@ struct PMTraceConsumer : ITraceConsumer
     std::map<uint32_t, ProcessInfo> mNewProcessesFromETW;
     std::vector<uint32_t> mDeadProcessIds;
 
+	// Time of the first event of the trace
+	uint64_t mTraceStartTime = 0;
+
     bool DequeuePresents(std::vector<std::shared_ptr<PresentEvent>>& outPresents)
     {
         if (mCompletedPresents.size())
@@ -1024,6 +1027,11 @@ void PMTraceConsumer::OnNTProcessEvent(PEVENT_RECORD pEventRecord)
 
 void PMTraceConsumer::OnEventRecord(PEVENT_RECORD pEventRecord)
 {
+	if (mTraceStartTime == 0)
+	{
+		mTraceStartTime = pEventRecord->EventHeader.TimeStamp.QuadPart;
+	}
+
     auto& hdr = pEventRecord->EventHeader;
 
     if (hdr.ProviderId == DXGI_PROVIDER_GUID)
@@ -1115,6 +1123,12 @@ void PresentMonEtw(const PresentMonArgs& args)
                 presents.clear();
                 newProcesses.clear();
                 deadProcesses.clear();
+
+				// If we are reading events from ETL file set start time to match time stamp of first event
+				if (data.mArgs->mEtlFileName && data.mStartupQpcTime == 0)
+				{
+					data.mStartupQpcTime = consumer.mTraceStartTime;
+				}
 
                 if (args.mEtlFileName) {
                     consumer.GetProcessEvents(newProcesses, deadProcesses);

--- a/main.cpp
+++ b/main.cpp
@@ -151,7 +151,7 @@ int main(int argc, char ** argv)
         }
     }
 
-    if (!HaveAdministratorPrivileges()) {
+    if (!args.mEtlFileName && !HaveAdministratorPrivileges()) {
         printf("Process is not running as admin. Attempting to elevate.\n");
         RestartAsAdministrator(argc, argv);
         return 0;


### PR DESCRIPTION
Don't require administrator privileges for reading from file, and fix up the timestamp column instead of using real-time QPC.