### PR TITLE
Add "simple" mode to PresentMon.

### DIFF
--- a/PresentMon.hpp
+++ b/PresentMon.hpp
@@ -110,6 +110,7 @@ struct PresentMonArgs {
     int mTimer = 0;
     bool mScrollLockToggle = false;
     bool mExcludeDropped = false;
+    bool mSimple = false;
 };
 
 struct PresentMonData {

--- a/main.cpp
+++ b/main.cpp
@@ -132,6 +132,10 @@ int main(int argc, char ** argv)
             {
                 args.mScrollLockToggle = true;
             }
+            else if (!strcmp(argv[i], "-simple"))
+            {
+                args.mSimple = true;
+            }
             else if (!strcmp(argv[i], "-?") || !strcmp(argv[i], "-help"))
             {
                 printHelp();


### PR DESCRIPTION
This reverts behavior back to pretty much right after my first commit to the project. There are still scenarios where PresentMon is not robust enough to handle full system capture (e.g. out-of-order present completion in multi-GPU scenarios, or swapchain re-creation which gets the same address). In scenarios where it breaks due to issues like these, running with "-simple" will turn off all advanced tracking and just capture fraps-like data.

Should resolve issue #11.