### PR TITLE
Add -terminate_on_proc_exit command line parameter.

### DIFF
--- a/PresentMon.cpp
+++ b/PresentMon.cpp
@@ -56,8 +56,12 @@ static void UpdateProcessInfo_Realtime(ProcessInfo& info, uint64_t now, uint32_t
                 info.mChainMap.clear();
                 info.mModuleName = name;
             }
-            CloseHandle(h);
+            DWORD dwExitCode = 0;
             info.mProcessExists = true;
+            if (GetExitCodeProcess(h, &dwExitCode) && dwExitCode != STILL_ACTIVE) {
+                info.mProcessExists = false;
+            }
+            CloseHandle(h);
         } else {
             info.mChainMap.clear();
             info.mProcessExists = false;

--- a/PresentMon.hpp
+++ b/PresentMon.hpp
@@ -99,6 +99,8 @@ struct ProcessInfo {
     uint64_t mLastRefreshTicks = 0; // GetTickCount64
     std::string mModuleName;
     std::map<uint64_t, SwapChainData> mChainMap;
+    bool mTerminationProcess;
+    bool mProcessExists = false;
 };
 
 struct PresentMonArgs {
@@ -111,6 +113,7 @@ struct PresentMonArgs {
     bool mScrollLockToggle = false;
     bool mExcludeDropped = false;
     bool mSimple = false;
+    bool mTerminateOnProcExit = false;
 };
 
 struct PresentMonData {
@@ -119,6 +122,7 @@ struct PresentMonData {
     std::string mOutputFilePath;
     FILE *mOutputFile = nullptr;
     std::map<uint32_t, ProcessInfo> mProcessMap;
+    uint32_t mTerminationProcessCount = 0;
 };
 
 void PresentMonEtw(const PresentMonArgs& args);

--- a/README.md
+++ b/README.md
@@ -16,4 +16,5 @@ ETW based FPS monitor for DX10+ programs, including Windows Store Apps / UWP App
  -exclude_dropped: exclude dropped presents from the csv output.
  -scroll_toggle: only record events while scroll lock is enabled.
  -simple: disable advanced tracking. try this if you encounter crashes.
+ -terminate_on_proc_exit: terminate PresentMon when all instances of the specified process exit.
 ```

--- a/main.cpp
+++ b/main.cpp
@@ -57,6 +57,7 @@ void printHelp()
         " -exclude_dropped: exclude dropped presents from the csv output.\n"
         " -scroll_toggle: only record events while scroll lock is enabled.\n"
         " -simple: disable advanced tracking. try this if you encounter crashes.\n"
+        " -terminate_on_proc_exit: terminate PresentMon when all instances of the specified process exit.\n"
         );
     printf("\nCSV columns explained (self explanatory columns omitted):\n"
         "  Dropped: boolean indicator. 1 = dropped, 0 = displayed.\n"
@@ -136,6 +137,10 @@ int main(int argc, char ** argv)
             else if (!strcmp(argv[i], "-simple"))
             {
                 args.mSimple = true;
+            }
+            else if (!strcmp(argv[i], "-terminate_on_proc_exit"))
+            {
+                args.mTerminateOnProcExit = true;
             }
             else if (!strcmp(argv[i], "-?") || !strcmp(argv[i], "-help"))
             {


### PR DESCRIPTION
This was useful for us incorporating PresentMon in some automated benchmarking, where the app runs a fixed scene and then terminates. We want PresentMon to terminate when the app does.