### PR TITLE
Fix non-D3D presents getting dropped by PresentMon in an attempt to a…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,4 @@ _Pvt_Extensions
 # JetBrains Rider
 .idea/
 *.sln.iml
+*.csv


### PR DESCRIPTION
…void getting stuck if D3D presents get started but never closed.

Implement handling of MMIOFlipMPO events being completed immediately. Works in the single-plane case at least.

Fixes #25 and #24.