### PR TITLE
Fix presents getting stuck in PresentMon.

### DIFF
--- a/source/PresentMonTraceConsumer.cpp
+++ b/source/PresentMonTraceConsumer.cpp
@@ -111,6 +111,14 @@ void PMTraceConsumer::OnDXGKrnlEvent(PEVENT_RECORD pEventRecord)
         // to trace the flip to screen.
         auto eventIter = FindOrCreatePresent(hdr);
 
+        // Check if we might have retrieved a 'stuck' present from a previous frame.
+        // The only events that we can expect before a Flip/FlipMPO are a runtime present start, or a previous FlipMPO.
+        if (eventIter->second->QueueSubmitSequence != 0 || eventIter->second->SeenDxgkPresent) {
+            // It's already progressed further but didn't complete, ignore it and create a new one.
+            mPresentByThreadId.erase(eventIter);
+            eventIter = FindOrCreatePresent(hdr);
+        }
+
         if (eventIter->second->PresentMode != PresentMode::Unknown) {
             // For MPO, N events may be issued, but we only care about the first
             return;
@@ -370,6 +378,15 @@ void PMTraceConsumer::OnDXGKrnlEvent(PEVENT_RECORD pEventRecord)
         // It gives us up to two different types of keys to correlate further.
         auto eventIter = FindOrCreatePresent(hdr);
 
+        // Check if we might have retrieved a 'stuck' present from a previous frame.
+        // This event always results in a classification, though for blts it's a clarifying classification.
+        if (eventIter->second->PresentMode != PresentMode::Unknown &&
+            eventIter->second->PresentMode != PresentMode::Hardware_Legacy_Copy_To_Front_Buffer) {
+            // It's already progressed further but didn't complete, ignore it and create a new one.
+            mPresentByThreadId.erase(eventIter);
+            eventIter = FindOrCreatePresent(hdr);
+        }
+
         if (eventIter->second->PresentMode == PresentMode::Hardware_Legacy_Copy_To_Front_Buffer) {
             auto TokenData = GetEventData<uint64_t>(pEventRecord, L"TokenData");
             mPresentsByLegacyBlitToken[TokenData] = eventIter->second;
@@ -423,6 +440,13 @@ void PMTraceConsumer::OnDXGKrnlEvent(PEVENT_RECORD pEventRecord)
     {
         auto eventIter = FindOrCreatePresent(hdr);
 
+        // Check if we might have retrieved a 'stuck' present from a previous frame.
+        // If the present mode isn't unknown at this point, we've already seen this present progress further
+        if (eventIter->second->PresentMode != PresentMode::Unknown) {
+            mPresentByThreadId.erase(eventIter);
+            eventIter = FindOrCreatePresent(hdr);
+        }
+
         eventIter->second->PresentMode = PresentMode::Hardware_Legacy_Copy_To_Front_Buffer;
         eventIter->second->SupportsTearing = true;
         break;
@@ -446,6 +470,14 @@ void PMTraceConsumer::OnWin32kEvent(PEVENT_RECORD pEventRecord)
     case Win32K_TokenCompositionSurfaceObject:
     {
         auto eventIter = FindOrCreatePresent(hdr);
+
+        // Check if we might have retrieved a 'stuck' present from a previous frame.
+        // If the present mode isn't unknown at this point, we've already seen this present progress further
+        if (eventIter->second->PresentMode != PresentMode::Unknown) {
+            mPresentByThreadId.erase(eventIter);
+            eventIter = FindOrCreatePresent(hdr);
+        }
+
         eventIter->second->PresentMode = PresentMode::Composed_Flip;
 
         Win32KPresentHistoryTokenKey key(GetEventData<uint64_t>(pEventRecord, L"pCompositionSurfaceObject"),
@@ -698,12 +730,7 @@ decltype(PMTraceConsumer::mPresentByThreadId.begin()) PMTraceConsumer::FindOrCre
     // Easy: we're on a thread that had some step in the present process
     auto eventIter = mPresentByThreadId.find(hdr.ThreadId);
     if (eventIter != mPresentByThreadId.end()) {
-        if (eventIter->second->Completed) {
-            mPresentByThreadId.erase(eventIter);
-        }
-        else {
-            return eventIter;
-        }
+        return eventIter;
     }
 
     // No such luck, check for batched presents


### PR DESCRIPTION
A once-and-for-all fix for not wanting presents to get 'stuck' in the present-by-thread map if we miss the critical event that would normally remove it from that map.

Previously, the attempt to fix this broke certain types of presents. To fix it without regressions, each consumer of FindOrCreatePresent will check to ensure that the found event meets its expectations. Most call sites should have 'brand new' presents with no previous information except maybe a runtime's PresentStart, except for FlipMPO (which can see a previous FlipMPO event for the same frame) and SubmitPresentHistory (which can see a Blt beforehand). Any other information stored in the present event will cause it to be discarded as likely 'stuck' and created anew.

With this, it's likely safe to start relaxing the lost events logic, as we should be much more robust to it. Data generated while events are getting dropped might not be accurate, but if events stop getting dropped we should recover. Once one present from a swapchain/process completes, all the previous ones will get flushed as 'unknown' completion state.