### PR TITLE
Add a -verbose mode which adds additional columns. Currently the only…

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Control and filtering options:
     -terminate_on_proc_exit    Terminate PresentMon when all instances of the specified process exit.
     -terminate_after_timed     Terminate PresentMon after the timed trace, specified using -timed, completes.
     -simple                    Disable advanced tracking (try this if you encounter crashes).
+    -verbose                   Adds additional data to output not relevant to normal usage.
     -dont_restart_as_admin     Don't try to elevate privilege.
     -no_top                    Don't display active swap chains in the console window.
 ```
@@ -76,4 +77,12 @@ Control and filtering options:
 | MsInPresentAPI         | Time spent inside the Present() API call |
 | MsUntilRenderComplete  | Time between present start and GPU work completion |
 | MsUntilDisplayed       | Time between present start and frame display |
+
+### Verbose Columns
+
+Columns output with the -verbose command line option.
+
+| CSV Column Header | CSV Data Description |
+|---|---|
+| WasBatched | The frame was submitted by the driver on a different thread than the app |
 

--- a/source/CommandLine.cpp
+++ b/source/CommandLine.cpp
@@ -244,6 +244,7 @@ void PrintHelp()
         "    -terminate_on_proc_exit    Terminate PresentMon when all instances of the specified process exit.\n"
         "    -terminate_after_timed     Terminate PresentMon after the timed trace, specified using -timed, completes.\n"
         "    -simple                    Disable advanced tracking (try this if you encounter crashes).\n"
+        "    -verbose                   Adds additional data to output not relevant to normal usage.\n"
         "    -dont_restart_as_admin     Don't try to elevate privilege.\n"
         "    -no_top                    Don't display active swap chains in the console window.\n"
         );
@@ -253,6 +254,8 @@ void PrintHelp()
 
 bool ParseCommandLine(int argc, char** argv, CommandLineArgs* args)
 {
+    bool simple = false;
+    bool verbose = false;
     for (int i = 1; i < argc; ++i) {
 #define ARG1(Arg, Assign) \
         if (strcmp(argv[i], Arg) == 0) { \
@@ -288,7 +291,8 @@ bool ParseCommandLine(int argc, char** argv, CommandLineArgs* args)
         else ARG1("-exclude_dropped",        args->mExcludeDropped      = true)
         else ARG1("-terminate_on_proc_exit", args->mTerminateOnProcExit = true)
         else ARG1("-terminate_after_timed",  args->mTerminateAfterTimer = true)
-        else ARG1("-simple",                 args->mSimple              = true)
+        else ARG1("-simple",                 simple                     = true)
+        else ARG1("-verbose",                verbose                    = true)
         else ARG1("-dont_restart_as_admin",  args->mTryToElevate        = false)
         else ARG1("-no_top",                 args->mSimpleConsole       = true)
 
@@ -328,6 +332,18 @@ bool ParseCommandLine(int argc, char** argv, CommandLineArgs* args)
             PrintHelp();
             return false;
         }
+    }
+
+    if (simple && verbose) {
+        fprintf(stderr, "error: -simple and -verbose arguments are not compatible.\n");
+        PrintHelp();
+        return false;
+    }
+    else if (simple) {
+        args->mVerbosity = Verbosity::Simple;
+    }
+    else if (verbose) {
+        args->mVerbosity = Verbosity::Verbose;
     }
 
     return true;

--- a/source/CommandLine.hpp
+++ b/source/CommandLine.hpp
@@ -23,6 +23,12 @@ SOFTWARE.
 #pragma once
 #include <windows.h>
 
+enum class Verbosity {
+    Simple,
+    Normal,
+    Verbose
+};
+
 // Target:           mTargetProcessName mTargetPid mEtlFileName
 //  All processes    nullptr            0          nullptr
 //  Process by name  process name       0          nullptr
@@ -42,7 +48,7 @@ struct CommandLineArgs {
     bool mScrollLockToggle = false;
     bool mScrollLockIndicator = false;
     bool mExcludeDropped = false;
-    bool mSimple = false;
+    Verbosity mVerbosity = Verbosity::Normal;
     bool mSimpleConsole = false;
     bool mTerminateOnProcExit = false;
     bool mTerminateAfterTimer = false;

--- a/source/PresentMonTraceConsumer.cpp
+++ b/source/PresentMonTraceConsumer.cpp
@@ -33,6 +33,7 @@ PresentEvent::PresentEvent(EVENT_HEADER const& hdr, ::Runtime runtime)
     , SupportsTearing(false)
     , MMIO(false)
     , SeenDxgkPresent(false)
+    , WasBatched(false)
     , Runtime(runtime)
     , TimeTaken(0)
     , ReadyTime(0)
@@ -337,6 +338,7 @@ void PMTraceConsumer::OnDXGKrnlEvent(PEVENT_RECORD pEventRecord)
             if (eventIter->second->TimeTaken == 0) {
                 eventIter->second->TimeTaken = EventTime - eventIter->second->QpcTime;
             }
+            eventIter->second->WasBatched = true;
             mPresentByThreadId.erase(eventIter);
         }
         break;

--- a/source/PresentMonTraceConsumer.hpp
+++ b/source/PresentMonTraceConsumer.hpp
@@ -88,6 +88,7 @@ struct PresentEvent {
     bool SupportsTearing;
     bool MMIO;
     bool SeenDxgkPresent;
+    bool WasBatched;
 
     Runtime Runtime;
 

--- a/source/SwapChainData.cpp
+++ b/source/SwapChainData.cpp
@@ -61,6 +61,7 @@ void SwapChainData::UpdateSwapChainInfo(PresentEvent&p, uint64_t now, uint64_t p
     mLastFlags = p.PresentFlags;
     mLastPresentMode = p.PresentMode;
     mLastPlane = p.PlaneIndex;
+    mHasBeenBatched = p.WasBatched;
 }
 
 double SwapChainData::ComputeFps(const std::deque<PresentEvent>& presentHistory, uint64_t qpcFreq)

--- a/source/SwapChainData.hpp
+++ b/source/SwapChainData.hpp
@@ -34,6 +34,7 @@ struct SwapChainData {
     std::deque<PresentEvent> mDisplayedPresentHistory;
     PresentMode mLastPresentMode = PresentMode::Unknown;
     uint32_t mLastPlane = 0;
+    bool mHasBeenBatched = false;
     
     void PruneDeque(std::deque<PresentEvent> &presentHistory, uint64_t perfFreq, uint32_t msTimeDiff, uint32_t maxHistLen);
     void AddPresentToSwapChain(PresentEvent& p);


### PR DESCRIPTION
… column is a "present batching" column, which indicates whether or not the driver is batching presents.

Internally merged with -simple using a verbosity enum.

I've been sitting on this change for months since I wasn't sure the concept of present batching would be useful outside of the Windows graphics team for debugging driver issues, but some conversations with coworkers convinced me it could be. I manually ported it over after all the refactoring that's been done and polished it up by putting it behind a -verbose option.