### PR TITLE
Add a verbose column to indicate that DWM has been notified of a part…

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,5 +84,6 @@ Columns output with the -verbose command line option.
 
 | CSV Column Header | CSV Data Description |
 |---|---|
-| WasBatched | The frame was submitted by the driver on a different thread than the app |
+| WasBatched  | The frame was submitted by the driver on a different thread than the app |
+| DwmNotified | The desktop compositor was notified about the frame. |
 

--- a/source/PresentMon.cpp
+++ b/source/PresentMon.cpp
@@ -217,7 +217,7 @@ void AddPresent(PresentMonData& pm, PresentEvent& p, uint64_t now, uint64_t perf
             }
             if (pm.mArgs->mVerbosity >= Verbosity::Verbose)
             {
-                fprintf(pm.mOutputFile, ",%d", curr.WasBatched);
+                fprintf(pm.mOutputFile, ",%d,%d", curr.WasBatched, curr.DwmNotified);
             }
             fprintf(pm.mOutputFile, ",%s,%.6lf,%.3lf", FinalStateToDroppedString(curr.FinalState), timeInSeconds, deltaMilliseconds);
             if (pm.mArgs->mVerbosity > Verbosity::Simple)
@@ -295,7 +295,7 @@ void PresentMon_Init(const CommandLineArgs& args, PresentMonData& pm)
             }
             if (pm.mArgs->mVerbosity >= Verbosity::Verbose)
             {
-                fprintf(pm.mOutputFile, ",WasBatched");
+                fprintf(pm.mOutputFile, ",WasBatched,DwmNotified");
             }
             fprintf(pm.mOutputFile, ",Dropped,TimeInSeconds,MsBetweenPresents");
             if (pm.mArgs->mVerbosity > Verbosity::Simple)
@@ -379,6 +379,14 @@ void PresentMon_Update(PresentMonData& pm, std::vector<std::shared_ptr<PresentEv
 
                 if (chain.second.mLastPresentMode == PresentMode::Hardware_Composed_Independent_Flip) {
                     _snprintf_s(str, _TRUNCATE, ": Plane %d", chain.second.mLastPlane);
+                    display += str;
+                }
+
+                if ((chain.second.mLastPresentMode == PresentMode::Hardware_Composed_Independent_Flip ||
+                     chain.second.mLastPresentMode == PresentMode::Hardware_Independent_Flip) &&
+                    pm.mArgs->mVerbosity >= Verbosity::Verbose &&
+                    chain.second.mDwmNotified) {
+                    _snprintf_s(str, _TRUNCATE, ", DWM notified");
                     display += str;
                 }
 

--- a/source/PresentMonTraceConsumer.hpp
+++ b/source/PresentMonTraceConsumer.hpp
@@ -92,6 +92,7 @@ struct PresentEvent {
     bool MMIO;
     bool SeenDxgkPresent;
     bool WasBatched;
+    bool DwmNotified;
 
     Runtime Runtime;
 
@@ -187,7 +188,7 @@ struct PMTraceConsumer
     // Win32K present history tokens are uniquely identified by (composition surface pointer, present count, bind id)
     // Using a tuple instead of named struct simply to have auto-generated comparison operators
     // These tokens are used for "flip model" presents (windowed flip, dFlip, iFlip) only
-    typedef std::tuple<uint64_t, uint64_t, uint32_t> Win32KPresentHistoryTokenKey;
+    typedef std::tuple<uint64_t, uint64_t, uint64_t> Win32KPresentHistoryTokenKey;
     std::map<Win32KPresentHistoryTokenKey, std::shared_ptr<PresentEvent>> mWin32KPresentHistoryTokens;
 
     // DxgKrnl present history tokens are uniquely identified by a single pointer

--- a/source/SwapChainData.cpp
+++ b/source/SwapChainData.cpp
@@ -61,6 +61,7 @@ void SwapChainData::UpdateSwapChainInfo(PresentEvent&p, uint64_t now, uint64_t p
     mLastPresentMode = p.PresentMode;
     mLastPlane = p.PlaneIndex;
     mHasBeenBatched = p.WasBatched;
+    mDwmNotified = p.DwmNotified;
 }
 
 double SwapChainData::ComputeFps(const std::deque<PresentEvent>& presentHistory, uint64_t qpcFreq)

--- a/source/SwapChainData.hpp
+++ b/source/SwapChainData.hpp
@@ -37,6 +37,7 @@ struct SwapChainData {
     PresentMode mLastPresentMode = PresentMode::Unknown;
     uint32_t mLastPlane = 0;
     bool mHasBeenBatched = false;
+    bool mDwmNotified = false;
     
     void PruneDeque(std::deque<PresentEvent> &presentHistory, uint64_t perfFreq, uint32_t msTimeDiff, uint32_t maxHistLen);
     void AddPresentToSwapChain(PresentEvent& p);


### PR DESCRIPTION
…icular present. This is mainly relevant for independent flip, so on-screen display of this fact is only done for these modes.

DWM may request to be notified of an app's presents if it has need of showing them somewhere besides the single screen where the app has entered independent flip - for example, opening a thumbnail view of the window on a second monitor.

This can be a root cause of some unexpected performance impact while in independent flip, but on its own is not an interesting performance metric, which is why it is under the verbose mode.