### PR TITLE
Add Win7 support.

### DIFF
--- a/PresentData/DxgkrnlEventStructs.hpp
+++ b/PresentData/DxgkrnlEventStructs.hpp
@@ -57,6 +57,7 @@ struct DxgkVSyncDPCEventArgs : DxgkEventBase
 struct DxgkSubmitPresentHistoryEventArgs : DxgkEventBase
 {
     uint64_t Token;
+    uint64_t TokenData;
     PresentMode KnownPresentMode;
 };
 

--- a/PresentData/DxgkrnlEventStructs.hpp
+++ b/PresentData/DxgkrnlEventStructs.hpp
@@ -1,0 +1,259 @@
+#pragma once
+
+// First, structures that can be produced either by processing legacy events
+// or modern manifest-based events.
+
+struct DxgkEventBase
+{
+    EVENT_HEADER const* pEventHeader;
+};
+
+struct DxgkBltEventArgs : DxgkEventBase
+{
+    uint64_t Hwnd;
+    bool Present;
+};
+
+struct DxgkFlipEventArgs : DxgkEventBase
+{
+    int32_t FlipInterval;
+    bool MMIO;
+};
+
+// A QueueSubmit can be many types, but these are interesting for present.
+enum class DxgKrnl_QueueSubmit_Type {
+    MMIOFlip = 3,
+    Software = 7,
+};
+struct DxgkQueueSubmitEventArgs : DxgkEventBase
+{
+    DxgKrnl_QueueSubmit_Type PacketType;
+    uint32_t SubmitSequence;
+    uint64_t Context;
+    bool Present;
+    bool SupportsDxgkPresentEvent;
+};
+
+struct DxgkQueueCompleteEventArgs : DxgkEventBase
+{
+    uint32_t SubmitSequence;
+};
+
+enum DxgKrnl_MMIOFlip_Flags {
+    FlipImmediate = 0x2,
+    FlipOnNextVSync = 0x4
+};
+struct DxgkMMIOFlipEventArgs : DxgkEventBase
+{
+    uint32_t FlipSubmitSequence;
+    DxgKrnl_MMIOFlip_Flags Flags;
+};
+
+struct DxgkVSyncDPCEventArgs : DxgkEventBase
+{
+    uint32_t FlipSubmitSequence;
+};
+
+struct DxgkSubmitPresentHistoryEventArgs : DxgkEventBase
+{
+    uint64_t Token;
+    PresentMode KnownPresentMode;
+};
+
+struct DxgkPropagatePresentHistoryEventArgs : DxgkEventBase
+{
+    uint64_t Token;
+};
+
+struct DxgkRetirePresentHistoryEventArgs : DxgkEventBase
+{
+    uint64_t Token;
+    PresentMode KnownPresentMode;
+};
+
+// These are the structures used to process the legacy events.
+
+//
+// Ensure that all ETW structure won't be aligned. This is necessary to
+// guarantee that a user mode application trying to get to this data
+// can get the same structure layout using a different compiler.
+//
+#pragma pack(push)
+#pragma pack(1)
+
+//
+// Dxgkrnl Blt Event
+//
+
+typedef struct _DXGKETW_PRESENTFLAGS
+{
+    struct
+    {
+        UINT    Blt : 1;    // 0x00000001
+        UINT    ColorFill : 1;    // 0x00000002
+        UINT    Flip : 1;    // 0x00000004
+        UINT    FlipWithNoWait : 1;    // 0x00000008
+        UINT    SrcColorKey : 1;    // 0x00000010
+        UINT    DstColorKey : 1;    // 0x00000020
+        UINT    LinearToSrgb : 1;    // 0x00000040
+        UINT    Rotate : 1;    // 0x00000080
+        UINT    Reserved : 24;    // 0xFFFFFF00
+    } Bits;
+} DXGKETW_PRESENTFLAGS;
+
+typedef struct _DXGKETW_BLTEVENT {
+    ULONGLONG                  hwnd;
+    ULONGLONG                  pDmaBuffer;
+    ULONGLONG                  PresentHistoryToken;
+    ULONGLONG                  hSourceAllocation;
+    ULONGLONG                  hDestAllocation;
+    BOOL                       bSubmit;
+    BOOL                       bRedirectedPresent;
+    DXGKETW_PRESENTFLAGS       Flags;
+    RECT                       SourceRect;
+    RECT                       DestRect;
+    UINT                       SubRectCount; // followed by variable number of ETWGUID_DXGKBLTRECT events
+} DXGKETW_BLTEVENT;
+
+//
+// Dxgkrnl Flip Event
+//
+
+typedef struct _DXGKETW_FLIPEVENT {
+    ULONGLONG                  pDmaBuffer;
+    ULONG                      VidPnSourceId;
+    ULONGLONG                  FlipToAllocation;
+    UINT                       FlipInterval; // D3DDDI_FLIPINTERVAL_TYPE
+    BOOLEAN                    FlipWithNoWait;
+    BOOLEAN                    MMIOFlip;
+} DXGKETW_FLIPEVENT;
+
+//
+// Dxgkrnl Present History Event.
+//
+
+typedef enum _D3DKMT_PRESENT_MODEL
+{
+    D3DKMT_PM_UNINITIALIZED = 0,
+    D3DKMT_PM_REDIRECTED_GDI = 1,
+    D3DKMT_PM_REDIRECTED_FLIP = 2,
+    D3DKMT_PM_REDIRECTED_BLT = 3,
+    D3DKMT_PM_REDIRECTED_VISTABLT = 4,
+    D3DKMT_PM_SCREENCAPTUREFENCE = 5,
+    D3DKMT_PM_REDIRECTED_GDI_SYSMEM = 6,
+    D3DKMT_PM_REDIRECTED_COMPOSITION = 7,
+} D3DKMT_PRESENT_MODEL;
+
+typedef struct _DXGKETW_PRESENTHISTORYEVENT {
+    ULONGLONG             hAdapter;
+    ULONGLONG             Token;
+    D3DKMT_PRESENT_MODEL  Model;     // available only for _STOP event type.
+    UINT                  TokenSize; // available only for _STOP event type.
+} DXGKETW_PRESENTHISTORYEVENT;
+
+//
+// Dxgkrnl Scheduler Submit QueuePacket Event
+//
+
+typedef enum _DXGKETW_QUEUE_PACKET_TYPE {
+    DXGKETW_RENDER_COMMAND_BUFFER = 0,
+    DXGKETW_DEFERRED_COMMAND_BUFFER = 1,
+    DXGKETW_SYSTEM_COMMAND_BUFFER = 2,
+    DXGKETW_MMIOFLIP_COMMAND_BUFFER = 3,
+    DXGKETW_WAIT_COMMAND_BUFFER = 4,
+    DXGKETW_SIGNAL_COMMAND_BUFFER = 5,
+    DXGKETW_DEVICE_COMMAND_BUFFER = 6,
+    DXGKETW_SOFTWARE_COMMAND_BUFFER = 7,
+    DXGKETW_PAGING_COMMAND_BUFFER = 8,
+} DXGKETW_QUEUE_PACKET_TYPE;
+
+typedef struct _DXGKETW_QUEUESUBMITEVENT {
+    ULONGLONG                  hContext;
+    DXGKETW_QUEUE_PACKET_TYPE  PacketType;
+    ULONG                      SubmitSequence;
+    ULONGLONG                  DmaBufferSize;
+    UINT                       AllocationListSize;
+    UINT                       PatchLocationListSize;
+    BOOL                       bPresent;
+    ULONGLONG                  hDmaBuffer;
+} DXGKETW_QUEUESUBMITEVENT;
+
+//
+// Dxgkrnl Scheduler Complete QueuePacket Event
+//
+
+typedef struct _DXGKETW_QUEUECOMPLETEEVENT {
+    ULONGLONG                  hContext;
+    ULONG                      PacketType;
+    ULONG                      SubmitSequence;
+    union {
+        BOOL                   bPreempted;
+        BOOL                   bTimeouted; // PacketType is WaitCommandBuffer.
+    };
+} DXGKETW_QUEUECOMPLETEEVENT;
+
+//
+// Dxgkrnl VSync Dpc event
+//
+
+typedef enum _DXGKETW_FLIPMODE_TYPE
+{
+    DXGKETW_FLIPMODE_NO_DEVICE = 0,
+    DXGKETW_FLIPMODE_IMMEDIATE = 1,
+    DXGKETW_FLIPMODE_VSYNC_HW_FLIP_QUEUE = 2,
+    DXGKETW_FLIPMODE_VSYNC_SW_FLIP_QUEUE = 3,
+    DXGKETW_FLIPMODE_VSYNC_BUILT_IN_WAIT = 4,
+    DXGKETW_FLIPMODE_IMMEDIATE_SW_FLIP_QUEUE = 5,
+} DXGKETW_FLIPMODE_TYPE;
+
+typedef LARGE_INTEGER PHYSICAL_ADDRESS;
+
+typedef struct _DXGKETW_SCHEDULER_VSYNC_DPC {
+    ULONGLONG                 pDxgAdapter;
+    UINT                      VidPnTargetId;
+    PHYSICAL_ADDRESS          ScannedPhysicalAddress;
+    UINT                      VidPnSourceId;
+    UINT                      FrameNumber;
+    LONGLONG                  FrameQPCTime;
+    ULONGLONG                 hFlipDevice;
+    DXGKETW_FLIPMODE_TYPE     FlipType;
+    union
+    {
+        ULARGE_INTEGER        FlipFenceId;
+        PHYSICAL_ADDRESS      FlipToAddress;
+    };
+} DXGKETW_SCHEDULER_VSYNC_DPC;
+
+//
+// Dxgkrnl Scheduler mmio flip event
+//
+
+// there is 2 version of structure due to pointer size difference
+// between x86 (32bits) and x64/ia64 (64bits).
+//
+
+typedef struct _DXGKETW_SCHEDULER_MMIO_FLIP_32 {
+    ULONGLONG        pDxgAdapter;
+    UINT             VidPnSourceId;
+    ULONG            FlipSubmitSequence; // ContextUserSubmissionId
+    UINT             FlipToDriverAllocation;
+    PHYSICAL_ADDRESS FlipToPhysicalAddress;
+    UINT             FlipToSegmentId;
+    UINT             FlipPresentId;
+    UINT             FlipPhysicalAdapterMask;
+    ULONG            Flags;
+} DXGKETW_SCHEDULER_MMIO_FLIP_32;
+
+typedef struct _DXGKETW_SCHEDULER_MMIO_FLIP_64 {
+    ULONGLONG        pDxgAdapter;
+    UINT             VidPnSourceId;
+    ULONG            FlipSubmitSequence; // ContextUserSubmissionId
+    ULONGLONG        FlipToDriverAllocation;
+    PHYSICAL_ADDRESS FlipToPhysicalAddress;
+    UINT             FlipToSegmentId;
+    UINT             FlipPresentId;
+    UINT             FlipPhysicalAdapterMask;
+    ULONG            Flags;
+} DXGKETW_SCHEDULER_MMIO_FLIP_64;
+
+#pragma pack(pop)

--- a/PresentData/PresentData.vcxproj
+++ b/PresentData/PresentData.vcxproj
@@ -158,6 +158,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="DxgkrnlEventStructs.hpp" />
     <ClInclude Include="PresentMonTraceConsumer.hpp" />
     <ClInclude Include="SwapChainData.hpp" />
     <ClInclude Include="TraceConsumer.hpp" />

--- a/PresentData/PresentData.vcxproj.filters
+++ b/PresentData/PresentData.vcxproj.filters
@@ -4,6 +4,7 @@
     <ClInclude Include="PresentMonTraceConsumer.hpp" />
     <ClInclude Include="SwapChainData.hpp" />
     <ClInclude Include="TraceConsumer.hpp" />
+    <ClInclude Include="DxgkrnlEventStructs.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="PresentMonTraceConsumer.cpp" />

--- a/PresentData/PresentMonTraceConsumer.cpp
+++ b/PresentData/PresentMonTraceConsumer.cpp
@@ -20,12 +20,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+#define NOMINMAX
 #include <algorithm>
 #include <d3d9.h>
 #include <dxgi.h>
 
 #include "PresentMonTraceConsumer.hpp"
 #include "TraceConsumer.hpp"
+#include "DxgkrnlEventStructs.hpp"
 
 PresentEvent::PresentEvent(EVENT_HEADER const& hdr, ::Runtime runtime)
     : QpcTime(*(uint64_t*) &hdr.TimeStamp)
@@ -37,6 +39,7 @@ PresentEvent::PresentEvent(EVENT_HEADER const& hdr, ::Runtime runtime)
     , SupportsTearing(false)
     , MMIO(false)
     , SeenDxgkPresent(false)
+    , SeenWin32KEvents(false)
     , WasBatched(false)
     , DwmNotified(false)
     , Runtime(runtime)
@@ -102,6 +105,253 @@ void HandleDXGIEvent(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer)
     }
 }
 
+void PMTraceConsumer::HandleDxgkBlt(DxgkBltEventArgs& args)
+{
+    auto eventIter = FindOrCreatePresent(*args.pEventHeader);
+
+    // Check if we might have retrieved a 'stuck' present from a previous frame.
+    // If the present mode isn't unknown at this point, we've already seen this present progress further
+    if (eventIter->second->PresentMode != PresentMode::Unknown) {
+        mPresentByThreadId.erase(eventIter);
+        eventIter = FindOrCreatePresent(*args.pEventHeader);
+    }
+
+    // This could be one of several types of presents. Further events will clarify.
+    // For now, assume that this is a blt straight into a surface which is already on-screen.
+    eventIter->second->PresentMode = args.Present ?
+        PresentMode::Composed_Copy_CPU_GDI : PresentMode::Hardware_Legacy_Copy_To_Front_Buffer;
+    eventIter->second->SupportsTearing = !args.Present;
+    eventIter->second->Hwnd = args.Hwnd;
+}
+
+void PMTraceConsumer::HandleDxgkFlip(DxgkFlipEventArgs& args)
+{
+    // A flip event is emitted during fullscreen present submission.
+    // Afterwards, expect an MMIOFlip packet on the same thread, used
+    // to trace the flip to screen.
+    auto eventIter = FindOrCreatePresent(*args.pEventHeader);
+
+    // Check if we might have retrieved a 'stuck' present from a previous frame.
+    // The only events that we can expect before a Flip/FlipMPO are a runtime present start, or a previous FlipMPO.
+    if (eventIter->second->QueueSubmitSequence != 0 || eventIter->second->SeenDxgkPresent) {
+        // It's already progressed further but didn't complete, ignore it and create a new one.
+        mPresentByThreadId.erase(eventIter);
+        eventIter = FindOrCreatePresent(*args.pEventHeader);
+    }
+
+    if (eventIter->second->PresentMode != PresentMode::Unknown) {
+        // For MPO, N events may be issued, but we only care about the first
+        return;
+    }
+
+    eventIter->second->MMIO = args.MMIO;
+    eventIter->second->PresentMode = PresentMode::Hardware_Legacy_Flip;
+
+    if (eventIter->second->SyncInterval == -1) {
+        eventIter->second->SyncInterval = args.FlipInterval;
+    }
+    if (!args.MMIO) {
+        eventIter->second->SupportsTearing = args.FlipInterval == 0;
+    }
+
+    // If this is the DWM thread, piggyback these pending presents on our fullscreen present
+    if (args.pEventHeader->ThreadId == DwmPresentThreadId) {
+        std::swap(eventIter->second->DependentPresents, mPresentsWaitingForDWM);
+        DwmPresentThreadId = 0;
+    }
+}
+
+void PMTraceConsumer::HandleDxgkQueueSubmit(DxgkQueueSubmitEventArgs& args)
+{
+    // If we know we're never going to get a DxgkPresent event for a given blt, then let's try to determine if it's a redirected blt or not.
+    // If it's redirected, then the SubmitPresentHistory event should've been emitted before submitting anything else to the same context,
+    // and therefore we'll know it's a redirected present by this point. If it's still non-redirected, then treat this as if it was a DxgkPresent
+    // event - the present will be considered completed once its work is done, or if the work is already done, complete it now.
+    if (!args.SupportsDxgkPresentEvent) {
+        auto eventIter = mBltsByDxgContext.find(args.Context);
+        if (eventIter != mBltsByDxgContext.end()) {
+            if (eventIter->second->PresentMode == PresentMode::Hardware_Legacy_Copy_To_Front_Buffer) {
+                eventIter->second->SeenDxgkPresent = true;
+                if (eventIter->second->ScreenTime != 0) {
+                    CompletePresent(eventIter->second);
+                }
+            }
+            mBltsByDxgContext.erase(eventIter);
+        }
+    }
+
+    // This event is emitted after a flip/blt/PHT event, and may be the only way
+    // to trace completion of the present.
+    if (args.PacketType == DxgKrnl_QueueSubmit_Type::MMIOFlip ||
+        args.PacketType == DxgKrnl_QueueSubmit_Type::Software ||
+        args.Present) {
+        auto eventIter = mPresentByThreadId.find(args.pEventHeader->ThreadId);
+        if (eventIter == mPresentByThreadId.end() || eventIter->second->QueueSubmitSequence != 0) {
+            return;
+        }
+
+        eventIter->second->QueueSubmitSequence = args.SubmitSequence;
+        mPresentsBySubmitSequence.emplace(args.SubmitSequence, eventIter->second);
+
+        if (eventIter->second->PresentMode == PresentMode::Hardware_Legacy_Copy_To_Front_Buffer && !args.SupportsDxgkPresentEvent) {
+            mBltsByDxgContext[args.Context] = eventIter->second;
+        }
+    }
+}
+
+void PMTraceConsumer::HandleDxgkQueueComplete(DxgkQueueCompleteEventArgs& args)
+{
+    auto eventIter = mPresentsBySubmitSequence.find(args.SubmitSequence);
+    if (eventIter == mPresentsBySubmitSequence.end()) {
+        return;
+    }
+
+    auto pEvent = eventIter->second;
+
+    uint64_t EventTime = *(uint64_t*)&args.pEventHeader->TimeStamp;
+
+    if (pEvent->PresentMode == PresentMode::Hardware_Legacy_Copy_To_Front_Buffer ||
+        (pEvent->PresentMode == PresentMode::Hardware_Legacy_Flip && !pEvent->MMIO)) {
+        pEvent->ScreenTime = pEvent->ReadyTime = EventTime;
+        pEvent->FinalState = PresentResult::Presented;
+
+        // Sometimes, the queue packets associated with a present will complete before the DxgKrnl present event is fired
+        // In this case, for blit presents, we have no way to differentiate between fullscreen and windowed blits
+        // So, defer the completion of this present until we know all events have been fired
+        if (pEvent->SeenDxgkPresent || pEvent->PresentMode != PresentMode::Hardware_Legacy_Copy_To_Front_Buffer) {
+            CompletePresent(pEvent);
+        }
+    }
+}
+
+void PMTraceConsumer::HandleDxgkMMIOFlip(DxgkMMIOFlipEventArgs& args)
+{
+    // An MMIOFlip event is emitted when an MMIOFlip packet is dequeued.
+    // This corresponds to all GPU work prior to the flip being completed
+    // (i.e. present "ready")
+    // It also is emitted when an independent flip PHT is dequed,
+    // and will tell us whether the present is immediate or vsync.
+    auto eventIter = mPresentsBySubmitSequence.find(args.FlipSubmitSequence);
+    if (eventIter == mPresentsBySubmitSequence.end()) {
+        return;
+    }
+
+    uint64_t EventTime = *(uint64_t*)&args.pEventHeader->TimeStamp;
+    eventIter->second->ReadyTime = EventTime;
+
+    if (eventIter->second->PresentMode == PresentMode::Composed_Flip) {
+        eventIter->second->PresentMode = PresentMode::Hardware_Independent_Flip;
+    }
+
+    if (args.Flags & DxgKrnl_MMIOFlip_Flags::FlipImmediate) {
+        eventIter->second->FinalState = PresentResult::Presented;
+        eventIter->second->ScreenTime = EventTime;
+        eventIter->second->SupportsTearing = true;
+        if (eventIter->second->PresentMode == PresentMode::Hardware_Legacy_Flip) {
+            CompletePresent(eventIter->second);
+        }
+    }
+}
+
+void PMTraceConsumer::HandleDxgkVSyncDPC(DxgkVSyncDPCEventArgs& args)
+{
+    // The VSyncDPC contains a field telling us what flipped to screen.
+    // This is the way to track completion of a fullscreen present.
+    auto eventIter = mPresentsBySubmitSequence.find(args.FlipSubmitSequence);
+    if (eventIter == mPresentsBySubmitSequence.end()) {
+        return;
+    }
+
+    uint64_t EventTime = *(uint64_t*)&args.pEventHeader->TimeStamp;
+    eventIter->second->ScreenTime = EventTime;
+    eventIter->second->FinalState = PresentResult::Presented;
+    if (eventIter->second->PresentMode == PresentMode::Hardware_Legacy_Flip) {
+        CompletePresent(eventIter->second);
+    }
+}
+
+void PMTraceConsumer::HandleDxgkSubmitPresentHistoryEventArgs(DxgkSubmitPresentHistoryEventArgs& args)
+{
+    // These events are emitted during submission of all types of windowed presents while DWM is on.
+    // It gives us up to two different types of keys to correlate further.
+    auto eventIter = FindOrCreatePresent(*args.pEventHeader);
+
+    // Check if we might have retrieved a 'stuck' present from a previous frame.
+    if (eventIter->second->TokenPtr != 0) {
+        // It's already progressed further but didn't complete, ignore it and create a new one.
+        mPresentByThreadId.erase(eventIter);
+        eventIter = FindOrCreatePresent(*args.pEventHeader);
+    }
+
+    eventIter->second->ReadyTime = eventIter->second->ScreenTime = 0;
+    eventIter->second->SupportsTearing = false;
+    eventIter->second->FinalState = PresentResult::Unknown;
+
+    if (eventIter->second->PresentMode == PresentMode::Hardware_Legacy_Copy_To_Front_Buffer)
+    {
+        eventIter->second->PresentMode = PresentMode::Composed_Copy_GPU_GDI;
+        assert(args.KnownPresentMode == PresentMode::Unknown ||
+               args.KnownPresentMode == PresentMode::Composed_Copy_GPU_GDI);
+    }
+    else if (eventIter->second->PresentMode == PresentMode::Unknown)
+    {
+        if (args.KnownPresentMode == PresentMode::Composed_Composition_Atlas) {
+            eventIter->second->PresentMode = PresentMode::Composed_Composition_Atlas;
+        }
+        else {
+            // When there's no Win32K events, we'll assume PHTs that aren't after a blt, and aren't composition tokens
+            // are flip tokens and that they're displayed. There are no Win32K events on Win7, and they might not be
+            // present in some traces - don't let presents get stuck/dropped just because we can't track them perfectly.
+            assert(!eventIter->second->SeenWin32KEvents);
+            eventIter->second->PresentMode = PresentMode::Composed_Flip;
+        }
+    }
+    mDxgKrnlPresentHistoryTokens[args.Token] = eventIter->second;
+}
+
+void PMTraceConsumer::HandleDxgkPropagatePresentHistoryEventArgs(DxgkPropagatePresentHistoryEventArgs& args)
+{
+    // This event is emitted when a token is being handed off to DWM, and is a good way to indicate a ready state
+    auto eventIter = mDxgKrnlPresentHistoryTokens.find(args.Token);
+    if (eventIter == mDxgKrnlPresentHistoryTokens.end()) {
+        return;
+    }
+
+    uint64_t EventTime = *(uint64_t*)&args.pEventHeader->TimeStamp;
+    auto& ReadyTime = eventIter->second->ReadyTime;
+    ReadyTime = (ReadyTime == 0 ?
+        EventTime : std::min(ReadyTime, EventTime));
+
+    if (eventIter->second->PresentMode == PresentMode::Composed_Composition_Atlas ||
+        (eventIter->second->PresentMode == PresentMode::Composed_Flip && !eventIter->second->SeenWin32KEvents)) {
+        mPresentsWaitingForDWM.emplace_back(eventIter->second);
+    }
+
+    if (eventIter->second->PresentMode == PresentMode::Composed_Copy_GPU_GDI) {
+        // Manipulate the map here
+        // When DWM is ready to present, we'll query for the most recent blt targeting this window and take it out of the map
+        mPresentByWindow[eventIter->second->Hwnd] = eventIter->second;
+    }
+
+    mDxgKrnlPresentHistoryTokens.erase(eventIter);
+}
+
+static PresentMode D3DKMT_TokenModel_ToPresentMode(D3DKMT_PRESENT_MODEL Model)
+{
+    switch (Model)
+    {
+    case D3DKMT_PM_REDIRECTED_BLT:
+        return PresentMode::Composed_Copy_GPU_GDI;
+    case D3DKMT_PM_REDIRECTED_VISTABLT:
+        return PresentMode::Composed_Copy_CPU_GDI;
+    case D3DKMT_PM_REDIRECTED_FLIP:
+        return PresentMode::Composed_Flip;
+    case D3DKMT_PM_REDIRECTED_COMPOSITION:
+        return PresentMode::Composed_Composition_Atlas;
+    }
+    return PresentMode::Unknown;
+}
+
 void HandleDXGKEvent(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer)
 {
     enum {
@@ -128,137 +378,52 @@ void HandleDXGKEvent(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer)
     case DxgKrnl_Flip:
     case DxgKrnl_FlipMPO:
     {
-        // A flip event is emitted during fullscreen present submission.
-        // Afterwards, expect an MMIOFlip packet on the same thread, used
-        // to trace the flip to screen.
-        auto eventIter = pmConsumer->FindOrCreatePresent(hdr);
-
-        // Check if we might have retrieved a 'stuck' present from a previous frame.
-        // The only events that we can expect before a Flip/FlipMPO are a runtime present start, or a previous FlipMPO.
-        if (eventIter->second->QueueSubmitSequence != 0 || eventIter->second->SeenDxgkPresent) {
-            // It's already progressed further but didn't complete, ignore it and create a new one.
-            pmConsumer->mPresentByThreadId.erase(eventIter);
-            eventIter = pmConsumer->FindOrCreatePresent(hdr);
-        }
-
-        if (eventIter->second->PresentMode != PresentMode::Unknown) {
-            // For MPO, N events may be issued, but we only care about the first
-            return;
-        }
-
-        eventIter->second->PresentMode = PresentMode::Hardware_Legacy_Flip;
+        DxgkFlipEventArgs Args = {};
+        Args.pEventHeader = &hdr;
+        Args.FlipInterval = -1;
         if (hdr.EventDescriptor.Id == DxgKrnl_Flip) {
-            if (eventIter->second->Runtime != Runtime::DXGI) {
-                // Only DXGI gives us the sync interval in the runtime present start event
-                GetEventData(pEventRecord, L"FlipInterval", &eventIter->second->SyncInterval);
-            }
-
-            eventIter->second->MMIO = GetEventData<BOOL>(pEventRecord, L"MMIOFlip") != 0;
+            Args.FlipInterval = GetEventData<uint32_t>(pEventRecord, L"FlipInterval");
+            Args.MMIO = GetEventData<BOOL>(pEventRecord, L"MMIOFlip") != 0;
         }
         else {
-            eventIter->second->MMIO = true; // All MPO flips are MMIO
+            Args.MMIO = true; // All MPO flips are MMIO
         }
-
-        // If this is the DWM thread, piggyback these pending presents on our fullscreen present
-        if (hdr.ThreadId == pmConsumer->DwmPresentThreadId) {
-            std::swap(eventIter->second->DependentPresents, pmConsumer->mPresentsWaitingForDWM);
-            pmConsumer->DwmPresentThreadId = 0;
-        }
+        pmConsumer->HandleDxgkFlip(Args);
         break;
     }
     case DxgKrnl_QueueSubmit:
     {
-        // A QueueSubmit can be many types, but these are interesting for present.
-        // This event is emitted after a flip/blt/PHT event, and may be the only way
-        // to trace completion of the present.
-        enum class DxgKrnl_QueueSubmit_Type {
-            MMIOFlip = 3,
-            Software = 7,
-        };
-        auto Type = GetEventData<DxgKrnl_QueueSubmit_Type>(pEventRecord, L"PacketType");
-        auto SubmitSequence = GetEventData<uint32_t>(pEventRecord, L"SubmitSequence");
-        bool Present = GetEventData<BOOL>(pEventRecord, L"bPresent") != 0;
-
-        if (Type == DxgKrnl_QueueSubmit_Type::MMIOFlip ||
-            Type == DxgKrnl_QueueSubmit_Type::Software ||
-            Present) {
-            auto eventIter = pmConsumer->mPresentByThreadId.find(hdr.ThreadId);
-            if (eventIter == pmConsumer->mPresentByThreadId.end()) {
-                return;
-            }
-
-            if (eventIter->second->QueueSubmitSequence == 0) {
-                eventIter->second->QueueSubmitSequence = SubmitSequence;
-                pmConsumer->mPresentsBySubmitSequence.emplace(SubmitSequence, eventIter->second);
-            }
-        }
-
+        DxgkQueueSubmitEventArgs Args = {};
+        Args.pEventHeader = &hdr;
+        Args.PacketType = GetEventData<DxgKrnl_QueueSubmit_Type>(pEventRecord, L"PacketType");
+        Args.SubmitSequence = GetEventData<uint32_t>(pEventRecord, L"SubmitSequence");
+        Args.Present = GetEventData<BOOL>(pEventRecord, L"bPresent") != 0;
+        Args.Context = GetEventData<uint64_t>(pEventRecord, L"hContext");
+        Args.SupportsDxgkPresentEvent = true;
+        pmConsumer->HandleDxgkQueueSubmit(Args);
         break;
     }
     case DxgKrnl_QueueComplete:
     {
-        auto SubmitSequence = GetEventData<uint32_t>(pEventRecord, L"SubmitSequence");
-        auto eventIter = pmConsumer->mPresentsBySubmitSequence.find(SubmitSequence);
-        if (eventIter == pmConsumer->mPresentsBySubmitSequence.end()) {
-            return;
-        }
-
-        auto pEvent = eventIter->second;
-
-        if (pEvent->PresentMode == PresentMode::Hardware_Legacy_Copy_To_Front_Buffer ||
-            (pEvent->PresentMode == PresentMode::Hardware_Legacy_Flip && !pEvent->MMIO)) {
-            pEvent->ScreenTime = pEvent->ReadyTime = EventTime;
-            pEvent->FinalState = PresentResult::Presented;
-
-            // Sometimes, the queue packets associated with a present will complete before the DxgKrnl present event is fired
-            // In this case, for blit presents, we have no way to differentiate between fullscreen and windowed blits
-            // So, defer the completion of this present until we know all events have been fired
-            if (pEvent->SeenDxgkPresent) {
-                pmConsumer->CompletePresent(pEvent);
-            }
-        }
+        DxgkQueueCompleteEventArgs Args = {};
+        Args.pEventHeader = &hdr;
+        Args.SubmitSequence = GetEventData<uint32_t>(pEventRecord, L"SubmitSequence");
+        pmConsumer->HandleDxgkQueueComplete(Args);
         break;
     }
     case DxgKrnl_MMIOFlip:
     {
-        // An MMIOFlip event is emitted when an MMIOFlip packet is dequeued.
-        // This corresponds to all GPU work prior to the flip being completed
-        // (i.e. present "ready")
-        // It also is emitted when an independent flip PHT is dequed,
-        // and will tell us whether the present is immediate or vsync.
-        enum DxgKrnl_MMIOFlip_Flags {
-            FlipImmediate = 0x2,
-            FlipOnNextVSync = 0x4
-        };
-
-        auto FlipSubmitSequence = GetEventData<uint32_t>(pEventRecord, L"FlipSubmitSequence");
-        auto Flags = GetEventData<DxgKrnl_MMIOFlip_Flags>(pEventRecord, L"Flags");
-
-        auto eventIter = pmConsumer->mPresentsBySubmitSequence.find(FlipSubmitSequence);
-        if (eventIter == pmConsumer->mPresentsBySubmitSequence.end()) {
-            return;
-        }
-
-        eventIter->second->ReadyTime = EventTime;
-        if (eventIter->second->PresentMode == PresentMode::Composed_Flip) {
-            eventIter->second->PresentMode = PresentMode::Hardware_Independent_Flip;
-        }
-
-        if (Flags & DxgKrnl_MMIOFlip_Flags::FlipImmediate) {
-            eventIter->second->FinalState = PresentResult::Presented;
-            eventIter->second->ScreenTime = *(uint64_t*)&pEventRecord->EventHeader.TimeStamp;
-            eventIter->second->SupportsTearing = true;
-            if (eventIter->second->PresentMode == PresentMode::Hardware_Legacy_Flip) {
-                pmConsumer->CompletePresent(eventIter->second);
-            }
-        }
-
+        DxgkMMIOFlipEventArgs Args = {};
+        Args.pEventHeader = &hdr;
+        Args.FlipSubmitSequence = GetEventData<uint32_t>(pEventRecord, L"FlipSubmitSequence");
+        Args.Flags = GetEventData<DxgKrnl_MMIOFlip_Flags>(pEventRecord, L"Flags");
+        pmConsumer->HandleDxgkMMIOFlip(Args);
         break;
     }
     case DxgKrnl_MMIOFlipMPO:
     {
         // See above for more info about this packet.
-        // Note: this packet currently does not support immediate flips
+        // Note: Event does not exist on Win7
         auto FlipFenceId = GetEventData<uint64_t>(pEventRecord, L"FlipSubmitSequence");
         uint32_t FlipSubmitSequence = (uint32_t)(FlipFenceId >> 32u);
 
@@ -291,7 +456,7 @@ void HandleDXGKEvent(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer)
                 eventIter->second->FinalState = PresentResult::Presented;
                 eventIter->second->SupportsTearing = true;
                 if (FlipEntryStatusAfterFlip == DxgKrnl_MMIOFlipMPO_FlipEntryStatus::FlipWaitComplete) {
-                    eventIter->second->ScreenTime = *(uint64_t*)&pEventRecord->EventHeader.TimeStamp;
+                    eventIter->second->ScreenTime = EventTime;
                 }
                 if (eventIter->second->PresentMode == PresentMode::Hardware_Legacy_Flip) {
                     pmConsumer->CompletePresent(eventIter->second);
@@ -303,56 +468,32 @@ void HandleDXGKEvent(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer)
     }
     case DxgKrnl_VSyncDPC:
     {
-        // The VSyncDPC contains a field telling us what flipped to screen.
-        // This is the way to track completion of a fullscreen present.
         auto FlipFenceId = GetEventData<uint64_t>(pEventRecord, L"FlipFenceId");
 
-        uint32_t FlipSubmitSequence = (uint32_t)(FlipFenceId >> 32u);
-        auto eventIter = pmConsumer->mPresentsBySubmitSequence.find(FlipSubmitSequence);
-        if (eventIter == pmConsumer->mPresentsBySubmitSequence.end()) {
-            return;
-        }
-
-        eventIter->second->ScreenTime = EventTime;
-        eventIter->second->FinalState = PresentResult::Presented;
-        if (eventIter->second->PresentMode == PresentMode::Hardware_Legacy_Flip) {
-            pmConsumer->CompletePresent(eventIter->second);
-        }
+        DxgkVSyncDPCEventArgs Args = {};
+        Args.pEventHeader = &hdr;
+        Args.FlipSubmitSequence = (uint32_t)(FlipFenceId >> 32u);
+        pmConsumer->HandleDxgkVSyncDPC(Args);
         break;
     }
     case DxgKrnl_Present:
     {
-        enum class DxgKrnl_Present_Flags {
-            RedirectedBlt = 0x00010000,
-        };
-
         // This event is emitted at the end of the kernel present, before returning.
-        // All other events have already been logged, but this one contains one
-        // extra piece of useful information: the hWnd that a present targeted,
-        // used to determine when presents are discarded instead of composed.
+        // The presence of this event is used with blt presents to indicate that no
+        // PHT is to be expected.
         auto eventIter = pmConsumer->mPresentByThreadId.find(hdr.ThreadId);
         if (eventIter == pmConsumer->mPresentByThreadId.end()) {
             return;
         }
 
-        auto hWnd = GetEventData<uint64_t>(pEventRecord, L"hWindow");
-        auto Flags = GetEventData<uint32_t>(pEventRecord, L"Flags");
-        if ((Flags & (uint32_t)DxgKrnl_Present_Flags::RedirectedBlt) != 0 &&
-            eventIter->second->PresentMode == PresentMode::Hardware_Legacy_Copy_To_Front_Buffer) {
-            // The present history token got dropped for some reason. Discard this present.
-            eventIter->second->PresentMode = PresentMode::Unknown;
-            eventIter->second->FinalState = PresentResult::Discarded;
-            pmConsumer->CompletePresent(eventIter->second);
+        eventIter->second->SeenDxgkPresent = true;
+        if (eventIter->second->Hwnd == 0) {
+            eventIter->second->Hwnd = GetEventData<uint64_t>(pEventRecord, L"hWindow");
         }
 
-        // For all other events, just remember the hWnd, we might need it later
-        eventIter->second->Hwnd = hWnd;
-        eventIter->second->SeenDxgkPresent = true;
-
-        if ((eventIter->second->PresentMode == PresentMode::Hardware_Legacy_Copy_To_Front_Buffer ||
-            (eventIter->second->PresentMode == PresentMode::Hardware_Legacy_Flip && !eventIter->second->MMIO)) &&
+        if (eventIter->second->PresentMode == PresentMode::Hardware_Legacy_Copy_To_Front_Buffer &&
             eventIter->second->ScreenTime != 0) {
-            // This is a fullscreen blit where all work associated was already done, so it's on-screen
+            // This is a fullscreen or DWM-off blit where all work associated was already done, so it's on-screen
             // It was deferred to here because there was no way to be sure it was really fullscreen until now
             pmConsumer->CompletePresent(eventIter->second);
         }
@@ -367,114 +508,136 @@ void HandleDXGKEvent(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer)
         break;
     }
     case DxgKrnl_PresentHistoryDetailed:
-    {
-        // This event is emitted during submission of most windowed presents.
-        // In the case of flip and blit model, it is used to find a key to watch for the
-        // event which triggers the "ready" state.
-        // In the case of blit model, it is also used to distinguish between fs/windowed.
-        auto eventIter = pmConsumer->mPresentByThreadId.find(hdr.ThreadId);
-        if (eventIter == pmConsumer->mPresentByThreadId.end()) {
-            return;
-        }
-
-        if (eventIter->second->PresentMode == PresentMode::Hardware_Legacy_Copy_To_Front_Buffer) {
-            eventIter->second->PresentMode = PresentMode::Composed_Copy_GPU_GDI;
-            eventIter->second->SupportsTearing = false;
-            // Overwrite some fields that may have been filled out while we thought it was fullscreen
-            assert(!eventIter->second->Completed);
-            eventIter->second->ReadyTime = eventIter->second->ScreenTime = 0;
-            eventIter->second->FinalState = PresentResult::Unknown;
-        }
-        uint64_t TokenPtr = GetEventData<uint64_t>(pEventRecord, L"Token");
-        pmConsumer->mDxgKrnlPresentHistoryTokens[TokenPtr] = eventIter->second;
-        break;
-    }
     case DxgKrnl_SubmitPresentHistory:
     {
-        // This event is emitted during submission of other types of windowed presents.
-        // It gives us up to two different types of keys to correlate further.
-        auto eventIter = pmConsumer->FindOrCreatePresent(hdr);
-
-        // Check if we might have retrieved a 'stuck' present from a previous frame.
-        // This event always results in a classification, though for blts it's a clarifying classification.
-        if (eventIter->second->PresentMode != PresentMode::Unknown &&
-            eventIter->second->PresentMode != PresentMode::Hardware_Legacy_Copy_To_Front_Buffer) {
-            // It's already progressed further but didn't complete, ignore it and create a new one.
-            pmConsumer->mPresentByThreadId.erase(eventIter);
-            eventIter = pmConsumer->FindOrCreatePresent(hdr);
-        }
-
-        if (eventIter->second->PresentMode == PresentMode::Hardware_Legacy_Copy_To_Front_Buffer) {
-            auto TokenData = GetEventData<uint64_t>(pEventRecord, L"TokenData");
-            pmConsumer->mPresentsByLegacyBlitToken[TokenData] = eventIter->second;
-
-            eventIter->second->ReadyTime = EventTime;
-            eventIter->second->PresentMode = PresentMode::Composed_Copy_CPU_GDI;
-            eventIter->second->SupportsTearing = false;
-        }
-        else if (eventIter->second->PresentMode == PresentMode::Unknown) {
-            enum class TokenModel {
-                Composition = 7,
-            };
-
-            auto Model = GetEventData<TokenModel>(pEventRecord, L"Model");
-            if (Model == TokenModel::Composition) {
-                eventIter->second->PresentMode = PresentMode::Composed_Composition_Atlas;
-                uint64_t TokenPtr = GetEventData<uint64_t>(pEventRecord, L"Token");
-                pmConsumer->mDxgKrnlPresentHistoryTokens[TokenPtr] = eventIter->second;
-            }
-        }
-
-        if (eventIter->second->Runtime == Runtime::Other ||
-            eventIter->second->PresentMode == PresentMode::Composed_Composition_Atlas)
-        {
-            // We're not expecting any other events from this thread (no DxgKrnl Present or EndPresent runtime event)
-            pmConsumer->mPresentByThreadId.erase(eventIter);
-        }
+        DxgkSubmitPresentHistoryEventArgs Args = {};
+        Args.pEventHeader = &hdr;
+        Args.Token = GetEventData<uint64_t>(pEventRecord, L"TokenData");
+        Args.KnownPresentMode = D3DKMT_TokenModel_ToPresentMode(
+            GetEventData<D3DKMT_PRESENT_MODEL>(pEventRecord, L"Model"));
+        pmConsumer->HandleDxgkSubmitPresentHistoryEventArgs(Args);
         break;
     }
     case DxgKrnl_PropagatePresentHistory:
     {
-        // This event is emitted when a token is being handed off to DWM, and is a good way to indicate a ready state
-        uint64_t TokenPtr = GetEventData<uint64_t>(pEventRecord, L"Token");
-        auto eventIter = pmConsumer->mDxgKrnlPresentHistoryTokens.find(TokenPtr);
-        if (eventIter == pmConsumer->mDxgKrnlPresentHistoryTokens.end()) {
-            return;
-        }
-
-        auto& ReadyTime = eventIter->second->ReadyTime;
-        ReadyTime = (ReadyTime == 0 ?
-            EventTime : min(ReadyTime, EventTime));
-
-        if (eventIter->second->PresentMode == PresentMode::Composed_Composition_Atlas) {
-            pmConsumer->mPresentsWaitingForDWM.emplace_back(eventIter->second);
-        }
-
-        if (eventIter->second->PresentMode == PresentMode::Composed_Copy_GPU_GDI) {
-            // Manipulate the map here
-            // When DWM is ready to present, we'll query for the most recent blt targeting this window and take it out of the map
-            pmConsumer->mPresentByWindow[eventIter->second->Hwnd] = eventIter->second;
-        }
-
-        pmConsumer->mDxgKrnlPresentHistoryTokens.erase(eventIter);
+        DxgkPropagatePresentHistoryEventArgs Args = {};
+        Args.pEventHeader = &hdr;
+        Args.Token = GetEventData<uint64_t>(pEventRecord, L"Token");
         break;
     }
     case DxgKrnl_Blit:
     {
-        auto eventIter = pmConsumer->FindOrCreatePresent(hdr);
-
-        // Check if we might have retrieved a 'stuck' present from a previous frame.
-        // If the present mode isn't unknown at this point, we've already seen this present progress further
-        if (eventIter->second->PresentMode != PresentMode::Unknown) {
-            pmConsumer->mPresentByThreadId.erase(eventIter);
-            eventIter = pmConsumer->FindOrCreatePresent(hdr);
-        }
-
-        eventIter->second->PresentMode = PresentMode::Hardware_Legacy_Copy_To_Front_Buffer;
-        eventIter->second->SupportsTearing = true;
+        DxgkBltEventArgs Args = {};
+        Args.pEventHeader = &hdr;
+        Args.Hwnd = GetEventData<uint64_t>(pEventRecord, L"hwnd");
+        Args.Present = GetEventData<uint32_t>(pEventRecord, L"bRedirectedPresent") != 0;
+        pmConsumer->HandleDxgkBlt(Args);
         break;
     }
     }
+}
+
+namespace Win7
+{
+void HandleDxgkBlt(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer)
+{
+    DxgkBltEventArgs Args = {};
+    Args.pEventHeader = &pEventRecord->EventHeader;
+    auto pBltEvent = reinterpret_cast<DXGKETW_BLTEVENT*>(pEventRecord->UserData);
+    Args.Hwnd = pBltEvent->hwnd;
+    Args.Present = pBltEvent->bRedirectedPresent != 0;
+    pmConsumer->HandleDxgkBlt(Args);
+}
+
+void HandleDxgkFlip(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer)
+{
+    DxgkFlipEventArgs Args = {};
+    Args.pEventHeader = &pEventRecord->EventHeader;
+    auto pFlipEvent = reinterpret_cast<DXGKETW_FLIPEVENT*>(pEventRecord->UserData);
+    Args.FlipInterval = pFlipEvent->FlipInterval;
+    Args.MMIO = pFlipEvent->MMIOFlip != 0;
+    pmConsumer->HandleDxgkFlip(Args);
+}
+
+void HandleDxgkPresentHistory(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer)
+{
+    if (pEventRecord->EventHeader.EventDescriptor.Opcode == EVENT_TRACE_TYPE_START)
+    {
+        DxgkSubmitPresentHistoryEventArgs Args = {};
+        Args.pEventHeader = &pEventRecord->EventHeader;
+        Args.KnownPresentMode = PresentMode::Unknown;
+        Args.Token = reinterpret_cast<DXGKETW_PRESENTHISTORYEVENT*>(pEventRecord->UserData)->Token;
+        pmConsumer->HandleDxgkSubmitPresentHistoryEventArgs(Args);
+    }
+    else if (pEventRecord->EventHeader.EventDescriptor.Opcode == EVENT_TRACE_TYPE_INFO)
+    {
+        DxgkPropagatePresentHistoryEventArgs Args = {};
+        Args.pEventHeader = &pEventRecord->EventHeader;
+        Args.Token = reinterpret_cast<DXGKETW_PRESENTHISTORYEVENT*>(pEventRecord->UserData)->Token;
+        pmConsumer->HandleDxgkPropagatePresentHistoryEventArgs(Args);
+    }
+}
+
+void HandleDxgkQueuePacket(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer)
+{
+    if (pEventRecord->EventHeader.EventDescriptor.Opcode == EVENT_TRACE_TYPE_START)
+    {
+        DxgkQueueSubmitEventArgs Args = {};
+        Args.pEventHeader = &pEventRecord->EventHeader;
+        auto pSubmitEvent = reinterpret_cast<DXGKETW_QUEUESUBMITEVENT*>(pEventRecord->UserData);
+        switch (pSubmitEvent->PacketType)
+        {
+        case DXGKETW_MMIOFLIP_COMMAND_BUFFER:
+            Args.PacketType = DxgKrnl_QueueSubmit_Type::MMIOFlip;
+            break;
+        case DXGKETW_SOFTWARE_COMMAND_BUFFER:
+            Args.PacketType = DxgKrnl_QueueSubmit_Type::Software;
+            break;
+        default:
+            Args.Present = pSubmitEvent->bPresent != 0;
+            break;
+        }
+        Args.SubmitSequence = pSubmitEvent->SubmitSequence;
+        Args.Context = pSubmitEvent->hContext;
+        pmConsumer->HandleDxgkQueueSubmit(Args);
+    }
+    else if (pEventRecord->EventHeader.EventDescriptor.Opcode == EVENT_TRACE_TYPE_STOP)
+    {
+        DxgkQueueCompleteEventArgs Args = {};
+        Args.pEventHeader = &pEventRecord->EventHeader;
+        auto pCompleteEvent = reinterpret_cast<DXGKETW_QUEUECOMPLETEEVENT*>(pEventRecord->UserData);
+        Args.SubmitSequence = pCompleteEvent->SubmitSequence;
+        pmConsumer->HandleDxgkQueueComplete(Args);
+    }
+}
+
+void HandleDxgkVSyncDPC(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer)
+{
+    DxgkVSyncDPCEventArgs Args = {};
+    Args.pEventHeader = &pEventRecord->EventHeader;
+    auto pVSyncDPCEvent = reinterpret_cast<DXGKETW_SCHEDULER_VSYNC_DPC*>(pEventRecord->UserData);
+    Args.FlipSubmitSequence = (uint32_t)(pVSyncDPCEvent->FlipFenceId.QuadPart >> 32u);
+    pmConsumer->HandleDxgkVSyncDPC(Args);
+}
+
+void HandleDxgkMMIOFlip(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer)
+{
+    DxgkMMIOFlipEventArgs Args = {};
+    Args.pEventHeader = &pEventRecord->EventHeader;
+    if (pEventRecord->EventHeader.Flags & EVENT_HEADER_FLAG_32_BIT_HEADER)
+    {
+        auto pMMIOFlipEvent = reinterpret_cast<DXGKETW_SCHEDULER_MMIO_FLIP_32*>(pEventRecord->UserData);
+        Args.Flags = static_cast<DxgKrnl_MMIOFlip_Flags>(pMMIOFlipEvent->Flags);
+        Args.FlipSubmitSequence = pMMIOFlipEvent->FlipSubmitSequence;
+    }
+    else
+    {
+        auto pMMIOFlipEvent = reinterpret_cast<DXGKETW_SCHEDULER_MMIO_FLIP_64*>(pEventRecord->UserData);
+        Args.Flags = static_cast<DxgKrnl_MMIOFlip_Flags>(pMMIOFlipEvent->Flags);
+        Args.FlipSubmitSequence = pMMIOFlipEvent->FlipSubmitSequence;
+    }
+    pmConsumer->HandleDxgkMMIOFlip(Args);
+}
 }
 
 void HandleWin32kEvent(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer)
@@ -502,6 +665,7 @@ void HandleWin32kEvent(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer)
         }
 
         eventIter->second->PresentMode = PresentMode::Composed_Flip;
+        eventIter->second->SeenWin32KEvents = true;
 
         PMTraceConsumer::Win32KPresentHistoryTokenKey key(GetEventData<uint64_t>(pEventRecord, L"CompositionSurfaceLuid"),
             GetEventData<uint64_t>(pEventRecord, L"PresentCount"),
@@ -600,9 +764,6 @@ void HandleDWMEvent(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer)
     enum {
         DWM_GetPresentHistory = 64,
         DWM_Schedule_Present_Start = 15,
-        DWM_FlipChain_Pending = 69,
-        DWM_FlipChain_Complete = 70,
-        DWM_FlipChain_Dirty = 101,
         DWM_Schedule_SurfaceUpdate = 196,
     };
 
@@ -628,28 +789,6 @@ void HandleDWMEvent(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer)
     case DWM_Schedule_Present_Start:
     {
         pmConsumer->DwmPresentThreadId = hdr.ThreadId;
-        break;
-    }
-    case DWM_FlipChain_Pending:
-    case DWM_FlipChain_Complete:
-    case DWM_FlipChain_Dirty:
-    {
-        // As it turns out, the 64-bit token data from the PHT submission is actually two 32-bit data chunks,
-        // corresponding to a "flip chain" id and present id
-        uint32_t flipChainId = (uint32_t)GetEventData<uint64_t>(pEventRecord, L"ulFlipChain");
-        uint32_t serialNumber = (uint32_t)GetEventData<uint64_t>(pEventRecord, L"ulSerialNumber");
-        uint64_t token = ((uint64_t)flipChainId << 32ull) | serialNumber;
-        auto flipIter = pmConsumer->mPresentsByLegacyBlitToken.find(token);
-        if (flipIter == pmConsumer->mPresentsByLegacyBlitToken.end()) {
-            return;
-        }
-
-        // Watch for multiple legacy blits completing against the same window
-        auto hWnd = (uint32_t)GetEventData<uint64_t>(pEventRecord, L"hwnd");
-        pmConsumer->mPresentByWindow[hWnd] = flipIter->second;
-        flipIter->second->DwmNotified = true;
-
-        pmConsumer->mPresentsByLegacyBlitToken.erase(flipIter);
         break;
     }
     case DWM_Schedule_SurfaceUpdate:
@@ -727,6 +866,9 @@ void PMTraceConsumer::CompletePresent(std::shared_ptr<PresentEvent> p)
         if (hWndIter != mPresentByWindow.end() && hWndIter->second == p) {
             mPresentByWindow.erase(hWndIter);
         }
+    }
+    if (p->TokenPtr != 0) {
+        mDxgKrnlPresentHistoryTokens.erase(p->TokenPtr);
     }
     auto& processMap = mPresentsByProcess[p->ProcessId];
     processMap.erase(p->QpcTime);

--- a/PresentData/PresentMonTraceConsumer.hpp
+++ b/PresentData/PresentMonTraceConsumer.hpp
@@ -55,6 +55,7 @@ namespace Win7
     struct __declspec(uuid("{295e0d8e-51ec-43b8-9cc6-9f79331d27d6}")) DXGKQUEUEPACKET_GUID_HOLDER;
     struct __declspec(uuid("{5ccf1378-6b2c-4c0f-bd56-8eeb9e4c5c77}")) DXGKVSYNCDPC_GUID_HOLDER;
     struct __declspec(uuid("{547820fe-5666-4b41-93dc-6cfd5dea28cc}")) DXGKMMIOFLIP_GUID_HOLDER;
+    struct __declspec(uuid("{8c9dd1ad-e6e5-4b07-b455-684a9d879900}")) DWM_PROVIDER_GUID_HOLDER;
     static const auto DXGKRNL_PROVIDER_GUID = __uuidof(DXGKRNL_PROVIDER_GUID_HOLDER);
     static const auto DXGKBLT_GUID = __uuidof(DXGKBLT_GUID_HOLDER);
     static const auto DXGKFLIP_GUID = __uuidof(DXGKFLIP_GUID_HOLDER);
@@ -62,6 +63,7 @@ namespace Win7
     static const auto DXGKQUEUEPACKET_GUID = __uuidof(DXGKQUEUEPACKET_GUID_HOLDER);
     static const auto DXGKVSYNCDPC_GUID = __uuidof(DXGKVSYNCDPC_GUID_HOLDER);
     static const auto DXGKMMIOFLIP_GUID = __uuidof(DXGKMMIOFLIP_GUID_HOLDER);
+    static const auto DWM_PROVIDER_GUID = __uuidof(DWM_PROVIDER_GUID_HOLDER);
 };
 
 // Forward-declare structs that will be used by both modern and legacy dxgkrnl events.
@@ -234,6 +236,9 @@ struct PMTraceConsumer
     std::deque<std::shared_ptr<PresentEvent>> mPresentsWaitingForDWM;
     // Used to understand that a flip event is coming from the DWM
     uint32_t DwmPresentThreadId = 0;
+
+    // Yet another unique way of tracking present history tokens, this time from DxgKrnl -> DWM, only for legacy blit
+    std::map<uint64_t, std::shared_ptr<PresentEvent>> mPresentsByLegacyBlitToken;
 
     // Process events
     std::mutex mNTProcessEventMutex;

--- a/PresentData/PresentMonTraceConsumer.hpp
+++ b/PresentData/PresentMonTraceConsumer.hpp
@@ -45,6 +45,35 @@ static const auto DWM_PROVIDER_GUID = __uuidof(DWM_PROVIDER_GUID_HOLDER);
 static const auto D3D9_PROVIDER_GUID = __uuidof(D3D9_PROVIDER_GUID_HOLDER);
 static const auto NT_PROCESS_EVENT_GUID = __uuidof(NT_PROCESS_EVENT_GUID_HOLDER);
 
+// These are only for Win7 support
+namespace Win7
+{
+    struct __declspec(uuid("{65cd4c8a-0848-4583-92a0-31c0fbaf00c0}")) DXGKRNL_PROVIDER_GUID_HOLDER;
+    struct __declspec(uuid("{069f67f2-c380-4a65-8a61-071cd4a87275}")) DXGKBLT_GUID_HOLDER;
+    struct __declspec(uuid("{22412531-670b-4cd3-81d1-e709c154ae3d}")) DXGKFLIP_GUID_HOLDER;
+    struct __declspec(uuid("{c19f763a-c0c1-479d-9f74-22abfc3a5f0a}")) DXGKPRESENTHISTORY_GUID_HOLDER;
+    struct __declspec(uuid("{295e0d8e-51ec-43b8-9cc6-9f79331d27d6}")) DXGKQUEUEPACKET_GUID_HOLDER;
+    struct __declspec(uuid("{5ccf1378-6b2c-4c0f-bd56-8eeb9e4c5c77}")) DXGKVSYNCDPC_GUID_HOLDER;
+    struct __declspec(uuid("{547820fe-5666-4b41-93dc-6cfd5dea28cc}")) DXGKMMIOFLIP_GUID_HOLDER;
+    static const auto DXGKRNL_PROVIDER_GUID = __uuidof(DXGKRNL_PROVIDER_GUID_HOLDER);
+    static const auto DXGKBLT_GUID = __uuidof(DXGKBLT_GUID_HOLDER);
+    static const auto DXGKFLIP_GUID = __uuidof(DXGKFLIP_GUID_HOLDER);
+    static const auto DXGKPRESENTHISTORY_GUID = __uuidof(DXGKPRESENTHISTORY_GUID_HOLDER);
+    static const auto DXGKQUEUEPACKET_GUID = __uuidof(DXGKQUEUEPACKET_GUID_HOLDER);
+    static const auto DXGKVSYNCDPC_GUID = __uuidof(DXGKVSYNCDPC_GUID_HOLDER);
+    static const auto DXGKMMIOFLIP_GUID = __uuidof(DXGKMMIOFLIP_GUID_HOLDER);
+};
+
+// Forward-declare structs that will be used by both modern and legacy dxgkrnl events.
+struct DxgkBltEventArgs;
+struct DxgkFlipEventArgs;
+struct DxgkQueueSubmitEventArgs;
+struct DxgkQueueCompleteEventArgs;
+struct DxgkMMIOFlipEventArgs;
+struct DxgkVSyncDPCEventArgs;
+struct DxgkSubmitPresentHistoryEventArgs;
+struct DxgkPropagatePresentHistoryEventArgs;
+
 template <typename mutex_t> std::unique_lock<mutex_t> scoped_lock(mutex_t &m)
 {
     return std::unique_lock<mutex_t>(m);
@@ -91,6 +120,7 @@ struct PresentEvent {
     bool SupportsTearing;
     bool MMIO;
     bool SeenDxgkPresent;
+    bool SeenWin32KEvents;
     bool WasBatched;
     bool DwmNotified;
 
@@ -111,6 +141,7 @@ struct PresentEvent {
     uint32_t QueueSubmitSequence;
     uint32_t RuntimeThread;
     uint64_t Hwnd;
+    uint64_t TokenPtr;
     std::deque<std::shared_ptr<PresentEvent>> DependentPresents;
     bool Completed;
 
@@ -191,6 +222,10 @@ struct PMTraceConsumer
     // These are used for all types of windowed presents to track a "ready" time
     std::map<uint64_t, std::shared_ptr<PresentEvent>> mDxgKrnlPresentHistoryTokens;
 
+    // For blt presents on Win7, it's not possible to distinguish between DWM-off or fullscreen blts, and the DWM-on blt to redirection bitmaps.
+    // The best we can do is make the distinction based on the next packet submitted to the context. If it's not a PHT, it's not going to DWM.
+    std::map<uint64_t, std::shared_ptr<PresentEvent>> mBltsByDxgContext;
+
     // Present by window, used for determining superceding presents
     // For windowed blit presents, when DWM issues a present event, we choose the most recent event as the one that will make it to screen
     std::map<uint64_t, std::shared_ptr<PresentEvent>> mPresentByWindow;
@@ -199,9 +234,6 @@ struct PMTraceConsumer
     std::deque<std::shared_ptr<PresentEvent>> mPresentsWaitingForDWM;
     // Used to understand that a flip event is coming from the DWM
     uint32_t DwmPresentThreadId = 0;
-
-    // Yet another unique way of tracking present history tokens, this time from DxgKrnl -> DWM, only for legacy blit
-    std::map<uint64_t, std::shared_ptr<PresentEvent>> mPresentsByLegacyBlitToken;
 
     // Process events
     std::mutex mNTProcessEventMutex;
@@ -218,6 +250,15 @@ struct PMTraceConsumer
         return false;
     }
 
+    void HandleDxgkBlt(DxgkBltEventArgs& args);
+    void HandleDxgkFlip(DxgkFlipEventArgs& args);
+    void HandleDxgkQueueSubmit(DxgkQueueSubmitEventArgs& args);
+    void HandleDxgkQueueComplete(DxgkQueueCompleteEventArgs& args);
+    void HandleDxgkMMIOFlip(DxgkMMIOFlipEventArgs& args);
+    void HandleDxgkVSyncDPC(DxgkVSyncDPCEventArgs& args);
+    void HandleDxgkSubmitPresentHistoryEventArgs(DxgkSubmitPresentHistoryEventArgs& args);
+    void HandleDxgkPropagatePresentHistoryEventArgs(DxgkPropagatePresentHistoryEventArgs& args);
+
     void CompletePresent(std::shared_ptr<PresentEvent> p);
     decltype(mPresentByThreadId.begin()) FindOrCreatePresent(EVENT_HEADER const& hdr);
     void RuntimePresentStart(PresentEvent &event);
@@ -231,3 +272,13 @@ void HandleDXGKEvent(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer);
 void HandleWin32kEvent(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer);
 void HandleDWMEvent(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer);
 
+// These are only for Win7 support
+namespace Win7
+{
+    void HandleDxgkBlt(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer);
+    void HandleDxgkFlip(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer);
+    void HandleDxgkPresentHistory(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer);
+    void HandleDxgkQueuePacket(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer);
+    void HandleDxgkVSyncDPC(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer);
+    void HandleDxgkMMIOFlip(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer);
+}

--- a/PresentData/SwapChainData.cpp
+++ b/PresentData/SwapChainData.cpp
@@ -58,7 +58,10 @@ void SwapChainData::UpdateSwapChainInfo(PresentEvent&p, uint64_t now, uint64_t p
     mRuntime = p.Runtime;
     mLastSyncInterval = p.SyncInterval;
     mLastFlags = p.PresentFlags;
-    mLastPresentMode = p.PresentMode;
+    if (p.FinalState == PresentResult::Presented) {
+        // Prevent overwriting a valid present mode with unknown for a frame that was dropped.
+        mLastPresentMode = p.PresentMode;
+    }
     mLastPlane = p.PlaneIndex;
     mHasBeenBatched = p.WasBatched;
     mDwmNotified = p.DwmNotified;

--- a/PresentMon/PresentMon.cpp
+++ b/PresentMon/PresentMon.cpp
@@ -458,16 +458,21 @@ void EtwConsumingThread(const CommandLineArgs& args)
 
     TraceSession session;
 
-    session.AddProvider(DXGI_PROVIDER_GUID, TRACE_LEVEL_INFORMATION, 0, 0, (EventHandlerFn) &HandleDXGIEvent, &pmConsumer);
-    session.AddProvider(D3D9_PROVIDER_GUID, TRACE_LEVEL_INFORMATION, 0, 0, (EventHandlerFn) &HandleD3D9Event, &pmConsumer);
+    session.AddProviderAndHandler(DXGI_PROVIDER_GUID, TRACE_LEVEL_INFORMATION, 0, 0, (EventHandlerFn) &HandleDXGIEvent, &pmConsumer);
+    session.AddProviderAndHandler(D3D9_PROVIDER_GUID, TRACE_LEVEL_INFORMATION, 0, 0, (EventHandlerFn) &HandleD3D9Event, &pmConsumer);
     if (args.mVerbosity != Verbosity::Simple) {
-        session.AddProvider(DXGKRNL_PROVIDER_GUID, TRACE_LEVEL_INFORMATION, 1,      0, (EventHandlerFn) &HandleDXGKEvent,   &pmConsumer);
-        session.AddProvider(WIN32K_PROVIDER_GUID,  TRACE_LEVEL_INFORMATION, 0x1000, 0, (EventHandlerFn) &HandleWin32kEvent, &pmConsumer);
-        session.AddProvider(DWM_PROVIDER_GUID,     TRACE_LEVEL_VERBOSE,     0,      0, (EventHandlerFn) &HandleDWMEvent,    &pmConsumer);
+        session.AddProviderAndHandler(DXGKRNL_PROVIDER_GUID, TRACE_LEVEL_INFORMATION, 1,      0, (EventHandlerFn) &HandleDXGKEvent,   &pmConsumer);
+        session.AddProviderAndHandler(WIN32K_PROVIDER_GUID,  TRACE_LEVEL_INFORMATION, 0x1000, 0, (EventHandlerFn) &HandleWin32kEvent, &pmConsumer);
+        session.AddProviderAndHandler(DWM_PROVIDER_GUID,     TRACE_LEVEL_VERBOSE,     0,      0, (EventHandlerFn) &HandleDWMEvent,    &pmConsumer);
+        session.AddProvider(Win7::DXGKRNL_PROVIDER_GUID, TRACE_LEVEL_INFORMATION, 1, 0);
     }
-    if (args.mEtlFileName != nullptr) {
-        session.AddProvider(NT_PROCESS_EVENT_GUID, TRACE_LEVEL_NONE, 0, 0, (EventHandlerFn) &HandleNTProcessEvent, &pmConsumer);
-    }
+    session.AddHandler(NT_PROCESS_EVENT_GUID,         (EventHandlerFn) &HandleNTProcessEvent,           &pmConsumer);
+    session.AddHandler(Win7::DXGKBLT_GUID,            (EventHandlerFn) &Win7::HandleDxgkBlt,            &pmConsumer);
+    session.AddHandler(Win7::DXGKFLIP_GUID,           (EventHandlerFn) &Win7::HandleDxgkFlip,           &pmConsumer);
+    session.AddHandler(Win7::DXGKPRESENTHISTORY_GUID, (EventHandlerFn) &Win7::HandleDxgkPresentHistory, &pmConsumer);
+    session.AddHandler(Win7::DXGKQUEUEPACKET_GUID,    (EventHandlerFn) &Win7::HandleDxgkQueuePacket,    &pmConsumer);
+    session.AddHandler(Win7::DXGKVSYNCDPC_GUID,       (EventHandlerFn) &Win7::HandleDxgkVSyncDPC,       &pmConsumer);
+    session.AddHandler(Win7::DXGKMMIOFLIP_GUID,       (EventHandlerFn) &Win7::HandleDxgkMMIOFlip,       &pmConsumer);
 
     if (!(args.mEtlFileName == nullptr
         ? session.InitializeRealtime("PresentMon", &EtwThreadsShouldQuit)

--- a/PresentMon/PresentMon.cpp
+++ b/PresentMon/PresentMon.cpp
@@ -461,9 +461,10 @@ void EtwConsumingThread(const CommandLineArgs& args)
     session.AddProviderAndHandler(DXGI_PROVIDER_GUID, TRACE_LEVEL_INFORMATION, 0, 0, (EventHandlerFn) &HandleDXGIEvent, &pmConsumer);
     session.AddProviderAndHandler(D3D9_PROVIDER_GUID, TRACE_LEVEL_INFORMATION, 0, 0, (EventHandlerFn) &HandleD3D9Event, &pmConsumer);
     if (args.mVerbosity != Verbosity::Simple) {
-        session.AddProviderAndHandler(DXGKRNL_PROVIDER_GUID, TRACE_LEVEL_INFORMATION, 1,      0, (EventHandlerFn) &HandleDXGKEvent,   &pmConsumer);
-        session.AddProviderAndHandler(WIN32K_PROVIDER_GUID,  TRACE_LEVEL_INFORMATION, 0x1000, 0, (EventHandlerFn) &HandleWin32kEvent, &pmConsumer);
-        session.AddProviderAndHandler(DWM_PROVIDER_GUID,     TRACE_LEVEL_VERBOSE,     0,      0, (EventHandlerFn) &HandleDWMEvent,    &pmConsumer);
+        session.AddProviderAndHandler(DXGKRNL_PROVIDER_GUID,   TRACE_LEVEL_INFORMATION, 1,      0, (EventHandlerFn) &HandleDXGKEvent,   &pmConsumer);
+        session.AddProviderAndHandler(WIN32K_PROVIDER_GUID,    TRACE_LEVEL_INFORMATION, 0x1000, 0, (EventHandlerFn) &HandleWin32kEvent, &pmConsumer);
+        session.AddProviderAndHandler(DWM_PROVIDER_GUID,       TRACE_LEVEL_VERBOSE,     0,      0, (EventHandlerFn) &HandleDWMEvent,    &pmConsumer);
+        session.AddProviderAndHandler(Win7::DWM_PROVIDER_GUID, TRACE_LEVEL_VERBOSE, 0, 0, (EventHandlerFn) &HandleDWMEvent, &pmConsumer);
         session.AddProvider(Win7::DXGKRNL_PROVIDER_GUID, TRACE_LEVEL_INFORMATION, 1, 0);
     }
     session.AddHandler(NT_PROCESS_EVENT_GUID,         (EventHandlerFn) &HandleNTProcessEvent,           &pmConsumer);


### PR DESCRIPTION
Add Win7 support. This should address #30. I've tested D3D9, DXGI, and Vulkan apps on Win7, both in realtime and from an ETL file. The interesting thing here is adding support for Win7's DxgKrnl/DWM provider data, which is somewhat different from Win8+. Additionally, I verified that PresentMon correctly handles DWM-off scenarios, which don't (really) exist on Win8+.

I did my best to regression test what I could. Let me know if you have specific scenarios I should try, or if you find things that are broken.