### PR TITLE
Add support for consuming XPerf's metadata provider.

### DIFF
--- a/PresentData/KernelTraceControl.h
+++ b/PresentData/KernelTraceControl.h
@@ -1,0 +1,182 @@
+/*++
+
+Copyright (c) Microsoft Corporation.  All rights reserved.
+
+Module Name:
+
+    KernelTraceControl.h
+
+Abstract:
+
+    Public headers for event tracing control applications,
+    consumers and providers
+
+--*/
+
+#ifndef _KERNELTRACECONTROL_H_
+#define _KERNELTRACECONTROL_H_
+
+#include <evntrace.h>
+#include <tdh.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//
+// Used only for NT Kernel Logger sessions. Tells the kernel logger which
+// events to trace. Combine with the flags in 
+// EVENT_TRACE_PROPERTIES.EnableFlags field.
+//
+#ifndef EVENT_TRACE_FLAG_DISPATCHER
+#define EVENT_TRACE_FLAG_DISPATCHER         0x00000800
+#endif
+
+#ifndef EVENT_TRACE_FLAG_VIRTUAL_ALLOC
+#define EVENT_TRACE_FLAG_VIRTUAL_ALLOC      0x00004000
+#endif
+
+//
+// Used only for NT Kernel Logger trace files. Use the following event types
+// to identify the actual event when consuming the events from trace file.
+//
+#ifndef EVENT_TRACE_TYPE_READYTHREAD
+#define EVENT_TRACE_TYPE_READYTHREAD        0x32
+#endif
+
+#ifndef EVENT_TRACE_TYPE_VIRTUAL_ALLOC
+#define EVENT_TRACE_TYPE_VIRTUAL_ALLOC      0x62
+#endif
+
+#ifndef EVENT_TRACE_TYPE_VIRTUAL_FREE
+#define EVENT_TRACE_TYPE_VIRTUAL_FREE       0x63
+#endif
+
+//
+// Flags to save extended information to the ETW trace file
+//
+#define EVENT_TRACE_MERGE_EXTENDED_DATA_NONE                0x00000000
+#define EVENT_TRACE_MERGE_EXTENDED_DATA_IMAGEID             0x00000001
+#define EVENT_TRACE_MERGE_EXTENDED_DATA_BUILDINFO           0x00000002
+#define EVENT_TRACE_MERGE_EXTENDED_DATA_VOLUME_MAPPING      0x00000004
+#define EVENT_TRACE_MERGE_EXTENDED_DATA_WINSAT              0x00000008
+#define EVENT_TRACE_MERGE_EXTENDED_DATA_EVENT_METADATA      0x00000010
+#define EVENT_TRACE_MERGE_EXTENDED_DATA_PERFTRACK_METADATA  0x00000020
+#define EVENT_TRACE_MERGE_EXTENDED_DATA_NETWORK_INTERFACE   0x00000040
+#define EVENT_TRACE_MERGE_EXTENDED_DATA_NGEN_PDB            0x00000080
+#define EVENT_TRACE_MERGE_EXTENDED_DATA_EMBEDDED_PDB        0x00000100
+
+
+#define EVENT_TRACE_MERGE_EXTENDED_DATA_COMPRESS_TRACE      0x10000000
+#define EVENT_TRACE_MERGE_EXTENDED_DATA_INJECT_ONLY         0x40000000
+
+#define EVENT_TRACE_MERGE_EXTENDED_DATA_DEFAULT             0x000FFFFF
+#define EVENT_TRACE_MERGE_EXTENDED_DATA_ALL                 0x0FFFFFFF
+
+//
+// Event GUID to identify events logged via EVENT_TRACE_MERGE_EXTENDED_DATA_EVENT_METADATA
+//
+DEFINE_GUID( // {BBCCF6C1-6CD1-48c4-80FF-839482E37671}
+    EventMetadataGuid, 
+    0xbbccf6c1, 
+    0x6cd1, 
+    0x48c4, 
+    0x80, 0xff, 0x83, 0x94, 0x82, 0xe3, 0x76, 0x71
+    );
+
+//
+// Event types to identify the events logged via EVENT_TRACE_MERGE_EXTENDED_DATA_EVENT_METADATA
+//
+#ifndef EVENT_METADATA_LOG_TYPE_TRACE_EVENT_INFO
+#define EVENT_METADATA_LOG_TYPE_TRACE_EVENT_INFO    0x20
+#endif
+
+#ifndef EVENT_METADATA_LOG_TYPE_EVENT_MAP_INFO
+#define EVENT_METADATA_LOG_TYPE_EVENT_MAP_INFO      0x21
+#endif
+
+//
+// Payload of the EVENT_METADATA_LOG_TYPE_TRACE_EVENT_INFO is EVENT_MAP_INFO
+// defined in TDH.h header file.
+//
+
+//
+// Payload of the event EVENT_METADATA_LOG_TYPE_EVENT_MAP_INFO
+//
+typedef struct _EVENT_METADATA_EVENT_MAP_INFO {
+    GUID            ProviderId;
+    EVENT_MAP_INFO  EventMapInfo;
+} EVENT_METADATA_EVENT_MAP_INFO, *PEVENT_METADATA_EVENT_MAP_INFO;
+
+//
+// Stores the event GUID and event trace type whose stack tracing has to be enabled.
+//
+typedef struct _STACK_TRACING_EVENT_ID {
+    GUID  EventGuid;
+    UCHAR Type;
+    UCHAR Reserved[7];
+} STACK_TRACING_EVENT_ID, *PSTACK_TRACING_EVENT_ID;
+
+
+//
+// API to start ETW Kernel tracing
+//
+__control_entrypoint(DllExport)
+ULONG
+WINAPI
+StartKernelTrace(
+    _Out_ PTRACEHANDLE TraceHandle,
+    _Inout_ PEVENT_TRACE_PROPERTIES Properties,
+    _In_reads_opt_(cStackTracingEventIds) const STACK_TRACING_EVENT_ID StackTracingEventIds[],
+    _In_  ULONG cStackTracingEventIds
+    );
+
+//
+// API to merge multiple ETW trace files into a single output file
+//
+__control_entrypoint(DllExport)
+ULONG
+WINAPI
+CreateMergedTraceFile(
+    _In_  LPCWSTR wszMergedFileName,
+    _In_reads_(cTraceFileNames) LPCWSTR wszTraceFileNames[],
+    _In_  ULONG cTraceFileNames,
+    _In_  DWORD dwExtendedDataFlags
+    );
+
+//
+// API to start a heap tracing on the specified PID(s)
+//
+__control_entrypoint(DllExport)
+ULONG
+WINAPI
+StartHeapTrace(
+    _Out_ PTRACEHANDLE TraceHandle,
+    _Inout_ PEVENT_TRACE_PROPERTIES Properties,
+    _In_z_ LPCWSTR wszSessionName,
+    _In_reads_opt_(cPids) const ULONG Pids[],
+    _In_  ULONG cPids,
+    _In_reads_opt_(cStackTracingEventIds) const STACK_TRACING_EVENT_ID StackTracingEventIds[],
+    _In_  ULONG cStackTracingEventIds
+    );
+
+//
+// API to update a running heap trace to trace on the specified PID(s)
+//
+__control_entrypoint(DllExport)
+ULONG
+WINAPI
+UpdateHeapTrace(
+    _Inout_ PEVENT_TRACE_PROPERTIES Properties,
+    _In_z_ LPCWSTR wszSessionName,
+    _In_reads_opt_(cPids) const ULONG Pids[],
+    _In_  ULONG cPids,
+    _In_reads_opt_(cStackTracingEventIds) const STACK_TRACING_EVENT_ID StackTracingEventIds[],
+    _In_  ULONG cStackTracingEventIds
+    );
+
+#ifdef __cplusplus
+}       // extern "C"
+#endif
+
+#endif  // _KERNELTRACECONTROL_H_

--- a/PresentData/MixedRealityTraceConsumer.hpp
+++ b/PresentData/MixedRealityTraceConsumer.hpp
@@ -226,7 +226,7 @@ struct LateStageReprojectionEvent {
 
 struct MRTraceConsumer
 {
-    MRTraceConsumer(bool simple) 
+    MRTraceConsumer(bool simple)
         : mSimpleMode(simple)
     {}
     ~MRTraceConsumer();

--- a/PresentData/PresentData.vcxproj
+++ b/PresentData/PresentData.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{892028E5-32F6-45FC-8AB2-90FCBCAC4BF6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>PresentData</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -41,7 +41,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
@@ -159,6 +159,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="DxgkrnlEventStructs.hpp" />
+    <ClInclude Include="KernelTraceControl.h" />
     <ClInclude Include="LateStageReprojectionData.hpp" />
     <ClInclude Include="MixedRealityTraceConsumer.hpp" />
     <ClInclude Include="PresentMonTraceConsumer.hpp" />

--- a/PresentData/PresentData.vcxproj.filters
+++ b/PresentData/PresentData.vcxproj.filters
@@ -7,6 +7,7 @@
     <ClInclude Include="DxgkrnlEventStructs.hpp" />
     <ClInclude Include="MixedRealityTraceConsumer.hpp" />
     <ClInclude Include="LateStageReprojectionData.hpp" />
+    <ClInclude Include="KernelTraceControl.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="PresentMonTraceConsumer.cpp" />

--- a/PresentData/PresentMonTraceConsumer.hpp
+++ b/PresentData/PresentMonTraceConsumer.hpp
@@ -32,6 +32,10 @@ SOFTWARE.
 #include <windows.h>
 #include <evntcons.h> // must include after windows.h
 
+#include <initguid.h>
+#include "KernelTraceControl.h"
+#include "TraceConsumer.hpp"
+
 struct __declspec(uuid("{CA11C036-0102-4A2D-A6AD-F03CFED5D3C9}")) DXGI_PROVIDER_GUID_HOLDER;
 struct __declspec(uuid("{802ec45a-1e99-4b83-9920-87c98277ba9d}")) DXGKRNL_PROVIDER_GUID_HOLDER;
 struct __declspec(uuid("{8c416c79-d49b-4f01-a467-e56d3aa8234c}")) WIN32K_PROVIDER_GUID_HOLDER;
@@ -155,6 +159,8 @@ struct PMTraceConsumer
 {
     PMTraceConsumer(bool simple) : mSimpleMode(simple) { }
     ~PMTraceConsumer();
+
+    EventMetadataContainer mMetadata;
 
     bool mSimpleMode;
 
@@ -287,6 +293,7 @@ void HandleD3D9Event(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer);
 void HandleDXGKEvent(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer);
 void HandleWin32kEvent(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer);
 void HandleDWMEvent(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer);
+void HandleMetadataEvent(EVENT_RECORD* pEventRecord, PMTraceConsumer* pmConsumer);
 
 // These are only for Win7 support
 namespace Win7

--- a/PresentData/TraceConsumer.cpp
+++ b/PresentData/TraceConsumer.cpp
@@ -218,11 +218,11 @@ const void* EventMetadataContainer::GetEventDataImpl(EVENT_RECORD* pEventRecord,
 {
     auto ProviderIter = mMetadata.find(pEventRecord->EventHeader.ProviderId);
     if (ProviderIter == mMetadata.end())
-        return false;
+        return nullptr;
 
     auto EventIter = ProviderIter->second.find(pEventRecord->EventHeader.EventDescriptor);
     if (EventIter == ProviderIter->second.end())
-        return false;
+        return nullptr;
 
     auto& tei = *reinterpret_cast<TRACE_EVENT_INFO*>(EventIter->second.get());
     uint32_t DataOffset = 0;

--- a/PresentData/TraceConsumer.cpp
+++ b/PresentData/TraceConsumer.cpp
@@ -26,6 +26,7 @@ SOFTWARE.
 #include <string>
 #include <windows.h>
 #include <tdh.h> // must include after windows.h
+#include <assert.h>
 
 #include "TraceConsumer.hpp"
 
@@ -128,7 +129,7 @@ void PrintEventProperty(FILE* fp, uintptr_t bufferAddr, EVENT_PROPERTY_INFO cons
 
 }
 
-void PrintEventInformation(FILE* fp, EVENT_RECORD* pEventRecord)
+void PrintEventInformationFromTdh(FILE* fp, EVENT_RECORD* pEventRecord)
 {
     ULONG bufferSize = 0;
     auto status = TdhGetEventInformation(pEventRecord, 0, nullptr, nullptr, &bufferSize);
@@ -154,7 +155,7 @@ void PrintEventInformation(FILE* fp, EVENT_RECORD* pEventRecord)
     }
 }
 
-std::wstring GetEventTaskName(EVENT_RECORD* pEventRecord)
+std::wstring GetEventTaskNameFromTdh(EVENT_RECORD* pEventRecord)
 {
     std::wstring taskName = L"";
     ULONG bufferSize = 0;
@@ -175,7 +176,7 @@ std::wstring GetEventTaskName(EVENT_RECORD* pEventRecord)
 }
 
 template <>
-bool GetEventData<std::string>(EVENT_RECORD* pEventRecord, wchar_t const* name, std::string* out, bool bPrintOnError)
+bool GetEventDataFromTdh<std::string>(EVENT_RECORD* pEventRecord, wchar_t const* name, std::string* out, bool bPrintOnError)
 {
     PROPERTY_DATA_DESCRIPTOR descriptor;
     descriptor.PropertyName = (ULONGLONG) name;
@@ -201,4 +202,66 @@ bool GetEventData<std::string>(EVENT_RECORD* pEventRecord, wchar_t const* name, 
     }
 
     return true;
+}
+
+void EventMetadataContainer::InsertMetadata(GUID const& Provider, EVENT_DESCRIPTOR const& EventDescriptor, TRACE_EVENT_INFO const* pInfo, SIZE_T TeiSize)
+{
+    auto& spCachedInfo = mMetadata[Provider][EventDescriptor];
+    if (!spCachedInfo)
+    {
+        spCachedInfo.reset(new byte[TeiSize]);
+        memcpy(spCachedInfo.get(), pInfo, TeiSize);
+    }
+}
+
+const void* EventMetadataContainer::GetEventDataImpl(EVENT_RECORD* pEventRecord, wchar_t const* name, SIZE_T* pSize)
+{
+    auto ProviderIter = mMetadata.find(pEventRecord->EventHeader.ProviderId);
+    if (ProviderIter == mMetadata.end())
+        return false;
+
+    auto EventIter = ProviderIter->second.find(pEventRecord->EventHeader.EventDescriptor);
+    if (EventIter == ProviderIter->second.end())
+        return false;
+
+    auto& tei = *reinterpret_cast<TRACE_EVENT_INFO*>(EventIter->second.get());
+    uint32_t DataOffset = 0;
+    for (uint32_t i = 0; i < tei.TopLevelPropertyCount; ++i)
+    {
+        auto& prop = tei.EventPropertyInfoArray[i];
+        // Don't handle nested structs or variable data lengths.
+        assert((prop.Flags & (PropertyParamLength | PropertyParamCount | PropertyStruct)) == 0);
+        if (prop.Flags & (PropertyParamLength | PropertyParamCount | PropertyStruct))
+        {
+            return nullptr;
+        }
+
+        uint32_t FieldSize = prop.length;
+        if (prop.nonStructType.InType == TDH_INTYPE_SIZET ||
+            prop.nonStructType.InType == TDH_INTYPE_POINTER)
+        {
+            FieldSize = (pEventRecord->EventHeader.Flags & EVENT_HEADER_FLAG_32_BIT_HEADER) ? 4 :
+                (pEventRecord->EventHeader.Flags & EVENT_HEADER_FLAG_64_BIT_HEADER) ? 8 : FieldSize;
+        }
+        if (wcscmp(TEI_PROPERTY_NAME(&tei, &prop), name) == 0)
+        {
+            *pSize = FieldSize * prop.count;
+            return reinterpret_cast<BYTE*>(pEventRecord->UserData) + DataOffset;
+        }
+        DataOffset += FieldSize;
+    }
+    return nullptr;
+}
+
+template <> bool EventMetadataContainer::GetEventData<std::string>(EVENT_RECORD* pEventRecord, wchar_t const* name, std::string* out)
+{
+    SIZE_T Size = 0;
+    const void* pData = GetEventDataImpl(pEventRecord, name, &Size);
+    if (pData != nullptr && Size > 0)
+    {
+        out->resize(Size + 1);
+        memcpy((BYTE*)out->data(), pData, Size);
+        return true;
+    }
+    return GetEventDataFromTdh(pEventRecord, name, out);
 }

--- a/PresentData/TraceConsumer.hpp
+++ b/PresentData/TraceConsumer.hpp
@@ -77,9 +77,9 @@ bool EventMetadataContainer::GetEventData(EVENT_RECORD* pEventRecord, wchar_t co
 {
     SIZE_T Size = 0;
     const void* pData = GetEventDataImpl(pEventRecord, name, &Size);
-    if (pData != nullptr && Size == sizeof(*out))
+    if (pData != nullptr && Size <= sizeof(*out))
     {
-        *out = *reinterpret_cast<T const*>(pData);
+        memcpy(out, pData, Size);
         return true;
     }
     return GetEventDataFromTdh(pEventRecord, name, out);

--- a/PresentData/TraceConsumer.hpp
+++ b/PresentData/TraceConsumer.hpp
@@ -25,13 +25,36 @@ SOFTWARE.
 #include <windows.h>
 #include <stdio.h>
 #include <string>
+#include <map>
+#include <memory>
 #include <tdh.h>
 
-void PrintEventInformation(FILE* fp, EVENT_RECORD* pEventRecord);
-std::wstring GetEventTaskName(EVENT_RECORD* pEventRecord);
+inline bool operator<(GUID const& lhs, GUID const& rhs)
+{
+    return memcmp(&lhs, &rhs, sizeof(lhs)) < 0;
+}
+inline bool operator<(EVENT_DESCRIPTOR const& lhs, EVENT_DESCRIPTOR const& rhs)
+{
+    return memcmp(&lhs, &rhs, sizeof(lhs)) < 0;
+}
+class EventMetadataContainer
+{
+public:
+    void InsertMetadata(GUID const& Provider, EVENT_DESCRIPTOR const& EventDescriptor, TRACE_EVENT_INFO const* pInfo, SIZE_T TeiSize);
+
+    template <typename T> bool GetEventData(EVENT_RECORD* pEventRecord, wchar_t const* name, T* out);
+    template <typename T> T GetEventData(EVENT_RECORD* pEventRecord, wchar_t const* name);
+
+private:
+    const void* GetEventDataImpl(EVENT_RECORD* pEventRecord, wchar_t const* name, SIZE_T* pSize);
+    std::map<GUID, std::map<EVENT_DESCRIPTOR, std::unique_ptr<byte[]>>> mMetadata;
+};
+
+void PrintEventInformationFromTdh(FILE* fp, EVENT_RECORD* pEventRecord);
+std::wstring GetEventTaskNameFromTdh(EVENT_RECORD* pEventRecord);
 
 template <typename T>
-bool GetEventData(EVENT_RECORD* pEventRecord, wchar_t const* name, T* out, bool bPrintOnError = true)
+bool GetEventDataFromTdh(EVENT_RECORD* pEventRecord, wchar_t const* name, T* out, bool bPrintOnError = true)
 {
     PROPERTY_DATA_DESCRIPTOR descriptor;
     descriptor.PropertyName = (ULONGLONG) name;
@@ -41,7 +64,7 @@ bool GetEventData(EVENT_RECORD* pEventRecord, wchar_t const* name, T* out, bool 
     if (status != ERROR_SUCCESS) {
         if (bPrintOnError) {
             fprintf(stderr, "error: could not get event %ls property (error=%lu).\n", name, status);
-            PrintEventInformation(stderr, pEventRecord);
+            PrintEventInformationFromTdh(stderr, pEventRecord);
         }
         return false;
     }
@@ -50,12 +73,35 @@ bool GetEventData(EVENT_RECORD* pEventRecord, wchar_t const* name, T* out, bool 
 }
 
 template <typename T>
-T GetEventData(EVENT_RECORD* pEventRecord, wchar_t const* name)
+bool EventMetadataContainer::GetEventData(EVENT_RECORD* pEventRecord, wchar_t const* name, T* out)
+{
+    SIZE_T Size = 0;
+    const void* pData = GetEventDataImpl(pEventRecord, name, &Size);
+    if (pData != nullptr && Size == sizeof(*out))
+    {
+        *out = *reinterpret_cast<T const*>(pData);
+        return true;
+    }
+    return GetEventDataFromTdh(pEventRecord, name, out);
+}
+
+template <typename T>
+T GetEventDataFromTdh(EVENT_RECORD* pEventRecord, wchar_t const* name)
 {
     T value = {};
-    auto ok = GetEventData(pEventRecord, name, &value);
+    auto ok = GetEventDataFromTdh(pEventRecord, name, &value);
     (void) ok;
     return value;
 }
 
-template <> bool GetEventData<std::string>(EVENT_RECORD* pEventRecord, wchar_t const* name, std::string* out, bool bPrintOnError);
+template <typename T>
+T EventMetadataContainer::GetEventData(EVENT_RECORD* pEventRecord, wchar_t const* name)
+{
+    T value = {};
+    auto ok = GetEventData(pEventRecord, name, &value);
+    (void)ok;
+    return value;
+}
+
+template <> bool GetEventDataFromTdh<std::string>(EVENT_RECORD* pEventRecord, wchar_t const* name, std::string* out, bool bPrintOnError);
+template <> bool EventMetadataContainer::GetEventData<std::string>(EVENT_RECORD* pEventRecord, wchar_t const* name, std::string* out);

--- a/PresentMon/PresentMon.cpp
+++ b/PresentMon/PresentMon.cpp
@@ -892,6 +892,7 @@ void EtwConsumingThread(const CommandLineArgs& args)
         session.AddProviderAndHandler(Win7::DWM_PROVIDER_GUID, TRACE_LEVEL_VERBOSE, 0, 0, (EventHandlerFn) &HandleDWMEvent, &pmConsumer);
         session.AddProvider(Win7::DXGKRNL_PROVIDER_GUID, TRACE_LEVEL_INFORMATION, 1, 0);
     }
+    session.AddHandler(EventMetadataGuid,             (EventHandlerFn) &HandleMetadataEvent,            &pmConsumer);
     session.AddHandler(NT_PROCESS_EVENT_GUID,         (EventHandlerFn) &HandleNTProcessEvent,           &pmConsumer);
     session.AddHandler(Win7::DXGKBLT_GUID,            (EventHandlerFn) &Win7::HandleDxgkBlt,            &pmConsumer);
     session.AddHandler(Win7::DXGKFLIP_GUID,           (EventHandlerFn) &Win7::HandleDxgkFlip,           &pmConsumer);

--- a/PresentMon/PresentMon.vcxproj
+++ b/PresentMon/PresentMon.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{4EB9794B-1F12-48CE-ADC1-917E9810F29E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>PresentMon</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -41,7 +41,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">


### PR DESCRIPTION
Implements #55 

This provider consists purely of events that were injected into ETL files during the merge process. On the machine doing the merge, TDH is queried and the resulting metadata is included in the stream, so events can be decoded on machines which don't have the same version of ETW manifests as the one which produced the ETL.

Windows Performance Toolkit comes with a KernelTraceControl.h containing the definition of the metadata provider GUID and the opcode value for the metadata events. These events payload a TRACE_EVENT_INFO struct for some other provider/event.

Unfortunately, TDH doesn't have APIs for decoding based on a provided TRACE_EVENT_INFO, only ones which operate on an internally-located TRACE_EVENT_INFO from (e.g.) an XML manifest. So the payload parsing has to be done manually. Currently, PresentMon only queries data from simple (no structs or arrays) events, so the parsing is kept simple.

For the MR data, all of the events are tracelogging, which contain their metadata within the event itself, so TDH can be used to parse those safely no matter what machine is doing the decoding.

Also... update the SDK version to the latest, since my home PC doesn't have the older ones. I'm open to reverting this portion if there's objections.