### PR TITLE
Allow PresentEvents to be constructed and removed like a PoD type

### DIFF
--- a/PresentData/MixedRealityTraceConsumer.cpp
+++ b/PresentData/MixedRealityTraceConsumer.cpp
@@ -122,11 +122,6 @@ LateStageReprojectionEvent::LateStageReprojectionEvent(EVENT_HEADER const& hdr)
 {
 }
 
-LateStageReprojectionEvent::~LateStageReprojectionEvent()
-{
-    assert(Completed || gMixedRealityTraceConsumer_Exiting);
-}
-
 MRTraceConsumer::~MRTraceConsumer()
 {
 #ifndef NDEBUG

--- a/PresentData/MixedRealityTraceConsumer.hpp
+++ b/PresentData/MixedRealityTraceConsumer.hpp
@@ -164,7 +164,6 @@ struct LateStageReprojectionEvent {
     bool Completed;
 
     LateStageReprojectionEvent(EVENT_HEADER const& hdr);
-    ~LateStageReprojectionEvent();
 
     inline bool IsValidAppFrame() const
     {

--- a/PresentData/PresentMonTraceConsumer.cpp
+++ b/PresentData/PresentMonTraceConsumer.cpp
@@ -98,26 +98,10 @@ PresentEvent::PresentEvent(EVENT_HEADER const& hdr, ::Runtime runtime)
 #endif
 }
 
-#ifndef NDEBUG
-static bool gPresentMonTraceConsumer_Exiting = false;
-#endif
-
-PresentEvent::~PresentEvent()
-{
-    assert(Completed || gPresentMonTraceConsumer_Exiting);
-}
-
 PMTraceConsumer::PMTraceConsumer(bool filteredEvents, bool simple)
     : mFilteredEvents(filteredEvents)
     , mSimpleMode(simple)
 {
-}
-
-PMTraceConsumer::~PMTraceConsumer()
-{
-#ifndef NDEBUG
-    gPresentMonTraceConsumer_Exiting = true;
-#endif
 }
 
 void PMTraceConsumer::HandleD3D9Event(EVENT_RECORD* pEventRecord)

--- a/PresentData/PresentMonTraceConsumer.hpp
+++ b/PresentData/PresentMonTraceConsumer.hpp
@@ -121,7 +121,6 @@ struct PresentEvent {
 #endif
 
     PresentEvent(EVENT_HEADER const& hdr, ::Runtime runtime);
-    ~PresentEvent();
 
 private:
     PresentEvent(PresentEvent const& copy); // dne
@@ -175,7 +174,6 @@ private:
 struct PMTraceConsumer
 {
     PMTraceConsumer(bool filteredEvents, bool simple);
-    ~PMTraceConsumer();
 
     EventMetadata mMetadata;
 

--- a/PresentMon/OutputThread.cpp
+++ b/PresentMon/OutputThread.cpp
@@ -254,6 +254,9 @@ static void AddPresents(std::vector<std::shared_ptr<PresentEvent>> const& presen
     auto i = *presentEventIndex;
     for (auto n = presentEvents.size(); i < n; ++i) {
         auto presentEvent = presentEvents[i];
+#ifdef NDDEBUG
+        assert(presentEvent->Completed);
+#endif // NDDEBUG
 
         // Stop processing events if we hit the next stop time.
         if (checkStopQpc && presentEvent->QpcTime >= stopQpc) {
@@ -307,6 +310,9 @@ static void AddPresents(LateStageReprojectionData* lsrData,
     auto i = *presentEventIndex;
     for (auto n = presentEvents.size(); i < n; ++i) {
         auto presentEvent = presentEvents[i];
+#ifdef NDDEBUG
+        assert(presentEvent->Completed);
+#endif // NDDEBUG
 
         // Stop processing events if we hit the next stop time.
         if (checkStopQpc && presentEvent->QpcTime >= stopQpc) {


### PR DESCRIPTION
PresentData's destructor has asserts to catch incomplete events being destroyed. While this can be useful scenarios, it creates unexpected behaviors when these events are copied for diagnostic or record-keeping purposes.

My perspective is that this assert is better done in the debugger to keep the code clean and easy to use.

Alternatively, additional flags could help as a workaround, but isn't as clean.