### PR TITLE
Add support for Blit Cancel events

### DIFF
--- a/PresentData/ETW/Microsoft_Windows_DxgKrnl.h
+++ b/PresentData/ETW/Microsoft_Windows_DxgKrnl.h
@@ -157,11 +157,6 @@ struct Blit_Info_Struct {
 };
 
 template<typename PointerT>
-struct Blit_Cancel_Struct {
-    PointerT    hwnd;
-};
-
-template<typename PointerT>
 struct Flip_Info_Struct {
     PointerT    pDmaBuffer;
     uint32_t    VidPnSourceId;

--- a/PresentData/ETW/Microsoft_Windows_DxgKrnl.h
+++ b/PresentData/ETW/Microsoft_Windows_DxgKrnl.h
@@ -111,6 +111,7 @@ enum class Channel : uint8_t {
 };
 
 EVENT_DESCRIPTOR_DECL(Blit_Info                     , 0x00a6, 0x00, 0x11, 0x04, 0x00, 0x0067, 0x4000000000000001)
+EVENT_DESCRIPTOR_DECL(Blit_Cancel                   , 0x01f5, 0x00, 0x11, 0x04, 0x00, 0x0135, 0x4000000000000001)
 EVENT_DESCRIPTOR_DECL(Flip_Info                     , 0x00a8, 0x00, 0x11, 0x00, 0x00, 0x0003, 0x4000000000000001)
 EVENT_DESCRIPTOR_DECL(FlipMultiPlaneOverlay_Info    , 0x00fc, 0x00, 0x11, 0x00, 0x00, 0x008f, 0x4000000000000001)
 EVENT_DESCRIPTOR_DECL(HSyncDPCMultiPlane_Info       , 0x017e, 0x00, 0x11, 0x00, 0x00, 0x00e6, 0x4000000000000001)
@@ -153,6 +154,11 @@ struct Blit_Info_Struct {
     int32_t     Dest_Top;
     int32_t     Dest_Bottom;
     uint32_t    SubRectCount;
+};
+
+template<typename PointerT>
+struct Blit_Cancel_Struct {
+    PointerT    hwnd;
 };
 
 template<typename PointerT>

--- a/PresentData/PresentMonTraceConsumer.cpp
+++ b/PresentData/PresentMonTraceConsumer.cpp
@@ -235,6 +235,16 @@ void PMTraceConsumer::HandleDxgkBlt(EVENT_HEADER const& hdr, uint64_t hwnd, bool
     }
 }
 
+void PMTraceConsumer::HandleDxgkBltCancel(EVENT_HEADER const& hdr)
+{
+    auto eventIter = mPresentByThreadId.find(hdr.ThreadId);
+
+    if (eventIter != mPresentByThreadId.end()) {
+        eventIter->second->FinalState = PresentResult::Discarded;
+        CompletePresent(eventIter->second);
+    }
+}
+
 void PMTraceConsumer::HandleDxgkFlip(EVENT_HEADER const& hdr, int32_t flipInterval, bool mmio)
 {
     // A flip event is emitted during fullscreen present submission.
@@ -705,6 +715,12 @@ void PMTraceConsumer::HandleDXGKEvent(EVENT_RECORD* pEventRecord)
 
         TRACK_PRESENT_PATH_GENERATE_ID();
         HandleDxgkBlt(hdr, hwnd, bRedirectedPresent);
+        break;
+    }
+    case Microsoft_Windows_DxgKrnl::Blit_Cancel::Id:
+    {
+        TRACK_PRESENT_PATH_GENERATE_ID();
+        HandleDxgkBltCancel(hdr);
         break;
     }
     default:

--- a/PresentData/PresentMonTraceConsumer.hpp
+++ b/PresentData/PresentMonTraceConsumer.hpp
@@ -309,6 +309,7 @@ struct PMTraceConsumer
     }
 
     void HandleDxgkBlt(EVENT_HEADER const& hdr, uint64_t hwnd, bool redirectedPresent);
+    void HandleDxgkBltCancel(EVENT_HEADER const& hdr);
     void HandleDxgkFlip(EVENT_HEADER const& hdr, int32_t flipInterval, bool mmio);
     void HandleDxgkQueueSubmit(EVENT_HEADER const& hdr, uint32_t packetType, uint32_t submitSequence, uint64_t context, bool present, bool supportsDxgkPresentEvent);
     void HandleDxgkQueueComplete(EVENT_HEADER const& hdr, uint32_t submitSequence);


### PR DESCRIPTION
There are cases where a Present Blit can be optimized out in kernel. In such cases, we return success to the caller, but issue no further work for the present, leaving PresentMon to see these as outstanding. A future OS release will issue a new ETW event when such a scenario occurs. This change detects this new event and marks the present as discarded.

Signed-off-by: Jeff Wickenheiser <jeffwick@microsoft.com>