### PR TITLE
Add ability to scope data collection to specified process id

### DIFF
--- a/PresentData/PresentMonTraceConsumer.cpp
+++ b/PresentData/PresentMonTraceConsumer.cpp
@@ -234,10 +234,9 @@ void PMTraceConsumer::HandleDxgkBlt(EVENT_HEADER const& hdr, uint64_t hwnd, bool
 
     if (eventIter->second->PresentMode != PresentMode::Unknown) {
         HandleStuckPresent(hdr, &eventIter);
-    }
-
-    if (eventIter == mPresentByThreadId.end()) {
-        return;
+        if (eventIter == mPresentByThreadId.end()) {
+           return;
+        }
     }
 
     TRACK_PRESENT_PATH_SAVE_GENERATED_ID(eventIter->second);
@@ -275,10 +274,9 @@ void PMTraceConsumer::HandleDxgkFlip(EVENT_HEADER const& hdr, int32_t flipInterv
 
     if (eventIter->second->QueueSubmitSequence != 0 || eventIter->second->SeenDxgkPresent) {
         HandleStuckPresent(hdr, &eventIter);
-    }
-
-    if (eventIter == mPresentByThreadId.end()) {
-        return;
+        if (eventIter == mPresentByThreadId.end()) {
+            return;
+        }
     }
 
     TRACK_PRESENT_PATH_SAVE_GENERATED_ID(eventIter->second);
@@ -495,10 +493,9 @@ void PMTraceConsumer::HandleDxgkSubmitPresentHistoryEventArgs(
 
     if (eventIter->second->TokenPtr != 0) {
         HandleStuckPresent(hdr, &eventIter);
-    }
-
-    if (eventIter == mPresentByThreadId.end()) {
-        return;
+        if (eventIter == mPresentByThreadId.end()) {
+           return;
+        }
     }
 
     TRACK_PRESENT_PATH_SAVE_GENERATED_ID(eventIter->second);
@@ -978,10 +975,9 @@ void PMTraceConsumer::HandleWin32kEvent(EVENT_RECORD* pEventRecord)
 
         if (eventIter->second->SeenWin32KEvents) {
             HandleStuckPresent(hdr, &eventIter);
-        }
-
-        if (eventIter == mPresentByThreadId.end()) {
-            return;
+            if (eventIter == mPresentByThreadId.end()) {
+                return;
+            }
         }
 
         TRACK_PRESENT_PATH(eventIter->second);

--- a/PresentMon/TraceSession.cpp
+++ b/PresentMon/TraceSession.cpp
@@ -41,11 +41,16 @@ bool StartTraceSession()
     auto expectFilteredEvents =
         args.mEtlFileName == nullptr && // Scope filtering based on event ID only works for realtime collection
         IsWindows8Point1OrGreater();    // and requires Win8.1+
+    auto filterProcessTracking = args.mTargetPid != 0; // Does not support process names at this point
 
     // Create consumers
-    gPMConsumer = new PMTraceConsumer(expectFilteredEvents, simple);
+    gPMConsumer = new PMTraceConsumer(expectFilteredEvents, simple, filterProcessTracking);
     if (includeWinMR) {
         gMRConsumer = new MRTraceConsumer(simple);
+    }
+
+    if (filterProcessTracking) {
+        gPMConsumer->AddTrackedProcessForFiltering(args.mTargetPid);
     }
 
     // Start the session;


### PR DESCRIPTION
This change allows PresentMon data collection to be scoped to specified processes (currently only supporting process ids). This reduces memory usage by not tracking unnecessary presents from other processes, improving beyond the current implementation where filtering is just applied to the output.

Signed-off-by: Jeff Wickenheiser jeffwick@microsoft.com