### PR TITLE
Fix failures in Gold Csv caused by platform-dependent printf rounding

### DIFF
--- a/Tests/GoldEtlCsvTests.cpp
+++ b/Tests/GoldEtlCsvTests.cpp
@@ -112,15 +112,17 @@ public:
 
                     // Doubles should be good for 15 digits of precision.
 
-                    double testNumber = strtod(a, nullptr);
-                    double goldNumber = strtod(b, nullptr);
+                    double testNumber, goldNumber;
+                    int testSucceededCount = sscanf_s(a, "%lf", &testNumber);
+                    int goldSucceededCount = sscanf_s(b, "%lf", &goldNumber);
+
                     const char* testDecimalAddr = strchr(a, '.');
                     const char* goldDecimalAddr = strchr(b, '.');
-                    if (testNumber != 0.0 && goldNumber != 0.0 && testDecimalAddr != NULL && goldDecimalAddr != NULL) {
+                    if (testSucceededCount == 1 && goldSucceededCount == 1 && testDecimalAddr != NULL && goldDecimalAddr != NULL) {
                         size_t testDecimalNumbersCount = (a + strlen(a)) - testDecimalAddr - 1;
                         size_t goldDecimalNumbersCount = (b + strlen(b)) - goldDecimalAddr - 1;
                         double difference = (testNumber * pow(10.0, testDecimalNumbersCount)) - (goldNumber * pow(10.0, goldDecimalNumbersCount));
-                        if (difference > -1.001 && difference < 1.001) {
+                        if (testDecimalNumbersCount == goldDecimalNumbersCount && difference > -1.001 && difference < 1.001) {
                             continue;
                         }
                     }

--- a/Tests/GoldEtlCsvTests.cpp
+++ b/Tests/GoldEtlCsvTests.cpp
@@ -102,21 +102,42 @@ public:
                 if (testCsv.headerColumnIndex_[h] != SIZE_MAX && goldCsv.headerColumnIndex_[h] != SIZE_MAX) {
                     char const* a = testCsv.cols_[testCsv.headerColumnIndex_[h]];
                     char const* b = goldCsv.cols_[goldCsv.headerColumnIndex_[h]];
-                    if (_stricmp(a, b) != 0) {
-                        if (rowOk) {
-                            rowOk = false;
-                            printf("GOLD = %ls\n", goldCsv_.c_str());
-                            printf("TEST = %ls\n", testCsv_.c_str());
-                            AddTestFailure(__FILE__, __LINE__, "Difference on line: %zu", testCsv.line_);
-                            printf("    COLUMN                    TEST VALUE                            GOLD VALUE\n");
-                        }
-
-                        auto r = printf("    %s", testCsv.GetHeader(h));
-                        printf("%*s", r < 29 ? 29 - r : 0, "");
-                        r = printf(" %s", a);
-                        printf("%*s", r < 38 ? 38 - r : 0, "");
-                        printf(" %s\n", b);
+                    if (_stricmp(a, b) == 0) {
+                        continue;
                     }
+
+                    // Floating point may be inconsistently rounded by printf accross different platforms.
+                    // Do a rounding check by ensuring the difference between the two numebrs are less than 
+                    // the final digit +-1.001
+
+                    // Doubles should be good for 15 digits of precision.
+
+                    double testNumber = strtod(a, nullptr);
+                    double goldNumber = strtod(b, nullptr);
+                    const char* testDecimalAddr = strchr(a, '.');
+                    const char* goldDecimalAddr = strchr(b, '.');
+                    if (testNumber != 0.0 && goldNumber != 0.0 && testDecimalAddr != NULL && goldDecimalAddr != NULL) {
+                        size_t testDecimalNumbersCount = (a + strlen(a)) - testDecimalAddr - 1;
+                        size_t goldDecimalNumbersCount = (b + strlen(b)) - goldDecimalAddr - 1;
+                        double difference = (testNumber * pow(10.0, testDecimalNumbersCount)) - (goldNumber * pow(10.0, goldDecimalNumbersCount));
+                        if (difference > -1.001 && difference < 1.001) {
+                            continue;
+                        }
+                    }
+
+                    if (rowOk) {
+                        rowOk = false;
+                        printf("GOLD = %ls\n", goldCsv_.c_str());
+                        printf("TEST = %ls\n", testCsv_.c_str());
+                        AddTestFailure(__FILE__, __LINE__, "Difference on line: %zu", testCsv.line_);
+                        printf("    COLUMN                    TEST VALUE                            GOLD VALUE\n");
+                    }
+
+                    auto r = printf("    %s", testCsv.GetHeader(h));
+                    printf("%*s", r < 29 ? 29 - r : 0, "");
+                    r = printf(" %s", a);
+                    printf("%*s", r < 38 ? 38 - r : 0, "");
+                    printf(" %s\n", b);
                 }
             }
             if (!reportAllCsvDiffs_ && !rowOk) {


### PR DESCRIPTION
printf has inconsistent rounding behavior accross different platforms, see:
https://www.exploringbinary.com/inconsistent-rounding-of-printed-floating-point-numbers/

This PR adds some comparison code to tolerate rounding errors on the smallest decimal point.

Previously, tests cases 0 and 3 returns respectively:

GoldEtlCsvTests.cpp(110): error: Difference on line: 326
    COLUMN                    TEST VALUE                            GOLD VALUE
    MsUntilDisplayed          16.312                                  16.313

GoldEtlCsvTests.cpp(110): error: Difference on line: 119
    COLUMN                    TEST VALUE                            GOLD VALUE
    MsInPresentAPI             0.062                                    0.063

Now both tests pass. Validated via printing that this path is only stepped into in these two cases.

Signed-off-by: Zuoming Shi <ZuomingShi@gmail.com>