### PR TITLE
Prevent rare present ordering from causing CompletePresent to enter an infinite loop

### DIFF
--- a/PresentData/PresentMonTraceConsumer.cpp
+++ b/PresentData/PresentMonTraceConsumer.cpp
@@ -1205,8 +1205,7 @@ void PMTraceConsumer::CompletePresent(std::shared_ptr<PresentEvent> p, uint32_t 
 {
     DebugCompletePresent(*p, recurseDepth);
 
-    if (p->Completed)
-    {
+    if (p->Completed && p->FinalState != PresentResult::Presented) {
         p->FinalState = PresentResult::Error;
     }
 
@@ -1245,7 +1244,6 @@ void PMTraceConsumer::CompletePresent(std::shared_ptr<PresentEvent> p, uint32_t 
 
     auto& presentDeque = mPresentsByProcessAndSwapChain[std::make_tuple(p->ProcessId, p->SwapChainAddress)];
     auto presentIter = presentDeque.begin();
-    assert(!presentIter->get()->Completed); // It wouldn't be here anymore if it was
 
     // Only if state is presented, remove all previous presents up till this one.
     if (p->FinalState == PresentResult::Presented) {

--- a/PresentData/PresentMonTraceConsumer.cpp
+++ b/PresentData/PresentMonTraceConsumer.cpp
@@ -1249,7 +1249,6 @@ void PMTraceConsumer::CompletePresent(std::shared_ptr<PresentEvent> p, uint32_t 
     if (p->FinalState == PresentResult::Presented) {
         while (*presentIter != p) {
             CompletePresent(*presentIter, recurseDepth + 1);
-            assert(presentIter != presentDeque.begin()); // Otherwise we enter an infinite loop.
             presentIter = presentDeque.begin();
         }
     }

--- a/PresentData/PresentMonTraceConsumer.cpp
+++ b/PresentData/PresentMonTraceConsumer.cpp
@@ -1208,7 +1208,6 @@ void PMTraceConsumer::CompletePresent(std::shared_ptr<PresentEvent> p, uint32_t 
     if (p->Completed)
     {
         p->FinalState = PresentResult::Error;
-        return;
     }
 
     // Complete all other presents that were riding along with this one (i.e. this one came from DWM)
@@ -1248,9 +1247,11 @@ void PMTraceConsumer::CompletePresent(std::shared_ptr<PresentEvent> p, uint32_t 
     auto presentIter = presentDeque.begin();
     assert(!presentIter->get()->Completed); // It wouldn't be here anymore if it was
 
+    // Only if state is presented, remove all previous presents up till this one.
     if (p->FinalState == PresentResult::Presented) {
         while (*presentIter != p) {
             CompletePresent(*presentIter, recurseDepth + 1);
+            assert(presentIter != presentDeque.begin()); // Otherwise we enter an infinite loop.
             presentIter = presentDeque.begin();
         }
     }


### PR DESCRIPTION
In rare scenarios, CompletePresent could enter into an infinite loop due to a flaw in CompletePresent's logic.

This is mainly due to the logic to complete presents in chronological order missing an edge case.

The case is as follows:

Present 1: Unknown state, Incomplete
Present 2: Discarded state, Complete
Present 3: Unknown state, incomplete

When present 3 completes with a Presented FinalState, it will attempt to drain Presents 1 and 2 in a while loop, it completes Present 1, but Present 2 will fail to drain because of an early return if we call CompletePresent on an already complete present.

Also remove some other logic that incorrectly assumes that a completed present will never be visited by CompletePresent again.