### PR TITLE
Fix IFlip Notify Mode where presents could be incorrectly dropped

### DIFF
--- a/PresentData/ETW/Microsoft_Windows_DxgKrnl.h
+++ b/PresentData/ETW/Microsoft_Windows_DxgKrnl.h
@@ -91,12 +91,13 @@ enum class Channel : uint8_t {
     static Keyword  const Keyword = (Keyword) keyword_; \
 };
 
-// NOTE: Blit_Cancel added manually
+// NOTE: Blit_Cancel, IndependentFlip_Info, HSyncDPCMultiPlane_Info added manually
 EVENT_DESCRIPTOR_DECL(Blit_Info                     , 0x00a6, 0x00, 0x11, 0x04, 0x00, 0x0067, 0x4000000000000001)
 EVENT_DESCRIPTOR_DECL(Blit_Cancel                   , 0x01f5, 0x00, 0x11, 0x04, 0x00, 0x0135, 0x4000000000000001)
 EVENT_DESCRIPTOR_DECL(Flip_Info                     , 0x00a8, 0x00, 0x11, 0x00, 0x00, 0x0003, 0x4000000000000001)
 EVENT_DESCRIPTOR_DECL(FlipMultiPlaneOverlay_Info    , 0x00fc, 0x00, 0x11, 0x00, 0x00, 0x008f, 0x4000000000000001)
 EVENT_DESCRIPTOR_DECL(HSyncDPCMultiPlane_Info       , 0x017e, 0x00, 0x11, 0x00, 0x00, 0x00e6, 0x4000000000000001)
+EVENT_DESCRIPTOR_DECL(IndependentFlip_Info          , 0x010a, 0x02, 0x11, 0x00, 0x00, 0x0097, 0x4000000000000001)
 EVENT_DESCRIPTOR_DECL(MMIOFlip_Info                 , 0x0074, 0x00, 0x11, 0x00, 0x00, 0x0011, 0x4000000000000001)
 EVENT_DESCRIPTOR_DECL(MMIOFlipMultiPlaneOverlay_Info, 0x0103, 0x03, 0x11, 0x00, 0x00, 0x0090, 0x4000000000000001)
 EVENT_DESCRIPTOR_DECL(Present_Info                  , 0x00b8, 0x01, 0x11, 0x00, 0x00, 0x006b, 0x4000000000000001)

--- a/PresentData/PresentMonTraceConsumer.cpp
+++ b/PresentData/PresentMonTraceConsumer.cpp
@@ -519,10 +519,7 @@ void PMTraceConsumer::HandleDxgkSyncDPCMPO(EVENT_HEADER const& hdr, uint32_t fli
         pEvent->FinalState = PresentResult::Presented;
     }
 
-    if (pEvent->PresentMode == PresentMode::Hardware_Composed_Independent_Flip ||
-        pEvent->PresentMode == PresentMode::Hardware_Independent_Flip) {
-        CompletePresent(pEvent);
-    }
+    CompletePresent(pEvent);
 }
 
 void PMTraceConsumer::HandleDxgkPresentHistory(

--- a/PresentData/PresentMonTraceConsumer.cpp
+++ b/PresentData/PresentMonTraceConsumer.cpp
@@ -470,12 +470,31 @@ void PMTraceConsumer::HandleDxgkMMIOFlipMPO(EVENT_HEADER const& hdr, uint32_t fl
     if (flipEntryStatusAfterFlip == (uint32_t) Microsoft_Windows_DxgKrnl::FlipEntryStatus::FlipWaitComplete) {
         pEvent->ScreenTime = hdr.TimeStamp.QuadPart;
     }
+
     if (pEvent->PresentMode == PresentMode::Hardware_Legacy_Flip) {
         CompletePresent(pEvent);
     }
 }
 
-void PMTraceConsumer::HandleDxgkSyncDPC(EVENT_HEADER const& hdr, uint32_t flipSubmitSequence, bool isMultiPlane)
+void PMTraceConsumer::HandleDxgkSyncDPC(EVENT_HEADER const& hdr, uint32_t flipSubmitSequence)
+{
+    // The VSyncDPC/HSyncDPC contains a field telling us what flipped to screen.
+    // This is the way to track completion of a fullscreen present.
+    auto pEvent = FindBySubmitSequence(flipSubmitSequence);
+    if (pEvent == nullptr) {
+        return;
+    }
+
+    TRACK_PRESENT_PATH_SAVE_GENERATED_ID(pEvent);
+
+    pEvent->ScreenTime = hdr.TimeStamp.QuadPart;
+    pEvent->FinalState = PresentResult::Presented;
+    if (pEvent->PresentMode == PresentMode::Hardware_Legacy_Flip) {
+        CompletePresent(pEvent);
+    }
+}
+
+void PMTraceConsumer::HandleDxgkSyncDPCMPO(EVENT_HEADER const& hdr, uint32_t flipSubmitSequence, bool isMultiPlane)
 {
     // The VSyncDPC/HSyncDPC contains a field telling us what flipped to screen.
     // This is the way to track completion of a fullscreen present.
@@ -498,9 +517,11 @@ void PMTraceConsumer::HandleDxgkSyncDPC(EVENT_HEADER const& hdr, uint32_t flipSu
     if (pEvent->FinalState != PresentResult::Presented) {
         pEvent->ScreenTime = hdr.TimeStamp.QuadPart;
         pEvent->FinalState = PresentResult::Presented;
-        if (pEvent->PresentMode == PresentMode::Hardware_Legacy_Flip) {
-            CompletePresent(pEvent);
-        }
+    }
+
+    if (pEvent->PresentMode == PresentMode::Hardware_Composed_Independent_Flip ||
+        pEvent->PresentMode == PresentMode::Hardware_Independent_Flip) {
+        CompletePresent(pEvent);
     }
 }
 
@@ -634,6 +655,22 @@ void PMTraceConsumer::HandleDXGKEvent(EVENT_RECORD* pEventRecord)
         HandleDxgkFlip(hdr, FlipInterval, MMIOFlip);
         break;
     }
+    case Microsoft_Windows_DxgKrnl::IndependentFlip_Info::Id:
+    {
+        EventDataDesc desc[] = {
+            { L"SubmitSequence" },
+        };
+        mMetadata.GetEventData(pEventRecord, desc, _countof(desc));
+        auto flipSubmitSequence = desc[0].GetData<uint32_t>();
+
+        auto pEvent = FindBySubmitSequence(flipSubmitSequence);
+
+        // We should not have already identified as hardware_composed - this can only be detected around Vsync/HsyncDPC time.
+        assert(pEvent->PresentMode != PresentMode::Hardware_Composed_Independent_Flip);
+        pEvent->PresentMode = PresentMode::Hardware_Independent_Flip;
+
+        break;
+    }
     case Microsoft_Windows_DxgKrnl::FlipMultiPlaneOverlay_Info::Id:
         TRACK_PRESENT_PATH_GENERATE_ID();
         HandleDxgkFlip(hdr, -1, true);
@@ -726,7 +763,7 @@ void PMTraceConsumer::HandleDXGKEvent(EVENT_RECORD* pEventRecord)
         auto isMultiPlane = activePlaneCount > 1;
         for (uint32_t i = 0; i < FlipCount; i++) {
             auto FlipId = mMetadata.GetEventData<uint64_t>(pEventRecord, L"FlipSubmitSequence", i);
-            HandleDxgkSyncDPC(hdr, (uint32_t)(FlipId >> 32u), isMultiPlane);
+            HandleDxgkSyncDPCMPO(hdr, (uint32_t)(FlipId >> 32u), isMultiPlane);
         }
         break;
     }
@@ -735,7 +772,7 @@ void PMTraceConsumer::HandleDXGKEvent(EVENT_RECORD* pEventRecord)
         TRACK_PRESENT_PATH_GENERATE_ID();
 
         auto FlipFenceId = mMetadata.GetEventData<uint64_t>(pEventRecord, L"FlipFenceId");
-        HandleDxgkSyncDPC(hdr, (uint32_t)(FlipFenceId >> 32u), false);
+        HandleDxgkSyncDPC(hdr, (uint32_t)(FlipFenceId >> 32u));
         break;
     }
     case Microsoft_Windows_DxgKrnl::Present_Info::Id:
@@ -1032,7 +1069,7 @@ void PMTraceConsumer::HandleWin7DxgkVSyncDPC(EVENT_RECORD* pEventRecord)
     auto pVSyncDPCEvent = reinterpret_cast<Win7::DXGKETW_SCHEDULER_VSYNC_DPC*>(pEventRecord->UserData);
 
     // Windows 7 does not support MultiPlaneOverlay.
-    HandleDxgkSyncDPC(pEventRecord->EventHeader, (uint32_t)(pVSyncDPCEvent->FlipFenceId.QuadPart >> 32u), false);
+    HandleDxgkSyncDPC(pEventRecord->EventHeader, (uint32_t)(pVSyncDPCEvent->FlipFenceId.QuadPart >> 32u));
 }
 
 void PMTraceConsumer::HandleWin7DxgkMMIOFlip(EVENT_RECORD* pEventRecord)

--- a/PresentData/PresentMonTraceConsumer.hpp
+++ b/PresentData/PresentMonTraceConsumer.hpp
@@ -343,7 +343,8 @@ struct PMTraceConsumer
     void HandleDxgkQueueComplete(EVENT_HEADER const& hdr, uint32_t submitSequence);
     void HandleDxgkMMIOFlip(EVENT_HEADER const& hdr, uint32_t flipSubmitSequence, uint32_t flags);
     void HandleDxgkMMIOFlipMPO(EVENT_HEADER const& hdr, uint32_t flipSubmitSequence, uint32_t flipEntryStatusAfterFlip, bool flipEntryStatusAfterFlipValid);
-    void HandleDxgkSyncDPC(EVENT_HEADER const& hdr, uint32_t flipSubmitSequence, bool isMultiplane);
+    void HandleDxgkSyncDPC(EVENT_HEADER const& hdr, uint32_t flipSubmitSequence);
+    void HandleDxgkSyncDPCMPO(EVENT_HEADER const& hdr, uint32_t flipSubmitSequence, bool isMultiplane);
     void HandleDxgkPresentHistory(EVENT_HEADER const& hdr, uint64_t token, uint64_t tokenData, PresentMode knownPresentMode);
     void HandleDxgkPresentHistoryInfo(EVENT_HEADER const& hdr, uint64_t token);
 


### PR DESCRIPTION
After some recent changes to DWM, some TokenStateChanged events can now come much later than expected. This causes iFlip presents that previously wait on that event to incorrectly become marked as dropped when a newer frame completes first.

We resolve this by allows iFlip presents to be completed without waiting on TokenStateChanged events (e.g. they can be completed by VSyncDPCMPO events). For iFlip, we don't need TokenStateChanged events to track the data we need.

This was locally validated to no longer falsely report drops on a trace NVidia submitted, and passes existing Gold Standard tests.