### PR TITLE
Fix issue where gQuit is not set to false when do StartOutputThread()

### DIFF
--- a/PresentMon/OutputThread.cpp
+++ b/PresentMon/OutputThread.cpp
@@ -585,7 +585,7 @@ void Output()
 void StartOutputThread()
 {
     InitializeCriticalSection(&gRecordingToggleCS);
-
+    gQuit = false;
     gThread = std::thread(Output);
 }
 


### PR DESCRIPTION
gQuit is false when initialized, and it is set to true when do StopOutputThread().

It works fine to collect data at the first time. However, if want to collect data again, it will break cycles because gQuit is still true.