### PR TITLE
Fix: NOMINMAX macro definition with #ifndef, using std::max/std::min instead of WINAPI ones

### DIFF
--- a/PresentData/MixedRealityTraceConsumer.cpp
+++ b/PresentData/MixedRealityTraceConsumer.cpp
@@ -1,7 +1,9 @@
 // Copyright (C) 2017-2020 Intel Corporation
 // SPDX-License-Identifier: MIT
 
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <algorithm>
 #include <d3d9.h>
 #include <dxgi.h>

--- a/PresentData/PresentMonTraceConsumer.hpp
+++ b/PresentData/PresentMonTraceConsumer.hpp
@@ -3,7 +3,9 @@
 
 #pragma once
 
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 
 #include <deque>
 #include <map>

--- a/PresentData/TraceSession.cpp
+++ b/PresentData/TraceSession.cpp
@@ -1,6 +1,10 @@
 // Copyright (C) 2020-2022 Intel Corporation
 // SPDX-License-Identifier: MIT
 
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
 #include <assert.h>
 #include <stddef.h>
 #include <windows.h>
@@ -112,7 +116,7 @@ struct FilteredProvider {
             AddKeyword((uint64_t) T::Keyword);
         }
 
-        maxLevel_ = max(maxLevel_, T::Level);
+        maxLevel_ = std::max(maxLevel_, T::Level);
     }
 
     ULONG Enable(

--- a/PresentMon/CommandLine.cpp
+++ b/PresentMon/CommandLine.cpp
@@ -5,7 +5,7 @@
 
 #ifndef NOMINMAX
 #define NOMINMAX
-#endif NOMINMAX
+#endif
 
 #include "PresentMon.hpp"
 #include <algorithm>

--- a/PresentMon/CommandLine.cpp
+++ b/PresentMon/CommandLine.cpp
@@ -3,7 +3,10 @@
 
 #include <generated/version.h>
 
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif NOMINMAX
+
 #include "PresentMon.hpp"
 #include <algorithm>
 

--- a/PresentMon/Console.cpp
+++ b/PresentMon/Console.cpp
@@ -1,6 +1,10 @@
 // Copyright (C) 2019-2021 Intel Corporation
 // SPDX-License-Identifier: MIT
 
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
 #include "PresentMon.hpp"
 
 static HANDLE gConsoleHandle = INVALID_HANDLE_VALUE;
@@ -49,7 +53,7 @@ static void vConsolePrint(char const* format, va_list args)
 
     int r = vsnprintf(s, n, format, args);
     if (r > 0) {
-        gConsoleWriteBufferIndex = min((uint32_t) (n - 1), gConsoleWriteBufferIndex + r);
+        gConsoleWriteBufferIndex = std::min((uint32_t) (n - 1), gConsoleWriteBufferIndex + r);
     }
 }
 

--- a/PresentMon/OutputThread.cpp
+++ b/PresentMon/OutputThread.cpp
@@ -1,6 +1,10 @@
 // Copyright (C) 2019-2022 Intel Corporation
 // SPDX-License-Identifier: MIT
 
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
 #include "PresentMon.hpp"
 
 #include <algorithm>
@@ -334,7 +338,7 @@ static void PruneHistory(
 {
     assert(processEvents.size() + presentEvents.size() + lsrEvents.size() > 0);
 
-    auto latestQpc = max(max(
+    auto latestQpc = std::max(std::max(
         processEvents.empty() ? 0ull : processEvents.back().QpcTime,
         presentEvents.empty() ? 0ull : presentEvents.back()->QpcTime),
         lsrEvents.empty()     ? 0ull : lsrEvents.back()->QpcTime);

--- a/Tests/PresentMonTests.h
+++ b/Tests/PresentMonTests.h
@@ -1,7 +1,9 @@
 // Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: MIT
 
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <gtest/gtest.h>
 #include <string>
 #include <unordered_map>


### PR DESCRIPTION
The reason: I have project wide defined `NOMINMAX` and get macro redefinition warning. I decided to wrap it up with `#ifndef` everywhere and change WinAPI max/min calls with STL functions. 