### PR TITLE
Fix undefined `int32`

### DIFF
--- a/IntelPresentMon/AppCef/source/util/CefValues.h
+++ b/IntelPresentMon/AppCef/source/util/CefValues.h
@@ -63,7 +63,7 @@ namespace p2c::client::util
 		}
 		else if constexpr (std::is_integral_v<T>)
 		{
-			return CefV8Value::CreateInt(int32(val));
+			return CefV8Value::CreateInt(int32_t(val));
 		}
 		else if constexpr (std::is_floating_point_v<T>)
 		{
@@ -71,7 +71,7 @@ namespace p2c::client::util
 		}
 		else if constexpr (std::is_enum_v<T>)
 		{
-			return CefV8Value::CreateInt(int32(val));
+			return CefV8Value::CreateInt(int32_t(val));
 		}
 		else if constexpr (std::is_same_v<std::string, T> || std::is_same_v<std::wstring, T>)
 		{


### PR DESCRIPTION
At least on [`cef_binary_122.1.8+g40272b5+chromium-122.0.6261.69`](https://cef-builds.spotifycdn.com/cef_binary_122.1.8%2Bg40272b5%2Bchromium-122.0.6261.69_windows64_minimal.tar.bz2) value type `int32` doesn't seem to exist anymore.
```
1>IntelPresentMon\AppCef\source\util\CefValues.h(68,33): error C3861: 'int32': identifier not found
```