### PR TITLE
AppCef: Check for non secure path

### DIFF
--- a/IntelPresentMon/AppCef/source/winmain.cpp
+++ b/IntelPresentMon/AppCef/source/winmain.cpp
@@ -119,6 +119,8 @@ LRESULT CALLBACK MessageWindowWndProc(HWND window_handle, UINT message, WPARAM w
     return DefWindowProc(window_handle, message, w_param, l_param);
 }
 
+#define PROGRAM_NAME "Intel PresentMon"
+
 HWND CreateBrowserWindow(HINSTANCE instance_handle, int show_minimize_or_maximize)
 {
     WNDCLASSEX wcex = { 0 };
@@ -136,7 +138,7 @@ HWND CreateBrowserWindow(HINSTANCE instance_handle, int show_minimize_or_maximiz
     RegisterClassEx(&wcex);
 
     HWND hwnd = CreateWindow(
-        BrowserWindowClassName, "Intel PresentMon",
+        BrowserWindowClassName, PROGRAM_NAME,
         WS_OVERLAPPEDWINDOW | WS_CLIPCHILDREN, 200, 20,
         1360, 1020, nullptr, nullptr, instance_handle, nullptr
     );
@@ -174,6 +176,20 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 {
     using namespace client;
     try {
+#ifdef NDEBUG
+        std::wstring _path = std::filesystem::current_path();
+        if (_path.find(L"\\Program Files\\", 0) == -1LL) // -1 means no offset was found
+        {
+            wchar_t msg[512]{};
+            (void)_snwprintf_s(msg, _countof(msg),
+                               L"Unable to start " PROGRAM_NAME " due to path not being in privileged location.\n"
+                               "Path: \"%s\"\n"
+                               "You must copy installation files to privileged location such as \"C:\\Program Files\".", _path.c_str());
+            MessageBoxW(nullptr, msg, L"" PROGRAM_NAME " Startup Error", MB_ICONERROR | MB_APPLMODAL | MB_SETFOREGROUND);
+            return -1;
+        }
+#endif
+#undef PROGRAM_NAME
         opt::init();
         util::BootServices();
 


### PR DESCRIPTION
Checks for non secure path, if not in `"Program Files"`, raise an error since it will hit `__debugbreak();` in libcef.dll. https://github.com/chromium/chromium/blob/d0988dbf7d0baed14bfe603aa8ab47ee77aa2372/content/browser/gpu/gpu_data_manager_impl_private.cc#L1788

```
 	libcef.dll!logging::LogMessage::HandleFatal(unsigned __int64 stack_start, const std::__Cr::basic_string<char,std::__Cr::char_traits<char>,std::__Cr::allocator<char>> & str_newline) Line 1036	C++
 	[Inline Frame] libcef.dll!logging::LogMessage::Flush::<lambda_0>::operator()() Line 740	C++
 	[Inline Frame] libcef.dll!absl::cleanup_internal::Storage<`lambda at ..\..\base\logging.cc:738:40'>::InvokeCallback() Line 87	C++
 	[Inline Frame] libcef.dll!absl::Cleanup<absl::cleanup_internal::Tag,`lambda at ..\..\base\logging.cc:738:40'>::~Cleanup() Line 106	C++
 	libcef.dll!logging::LogMessage::Flush() Line 923	C++
 	libcef.dll!logging::LogMessageFatal::~LogMessageFatal() Line 1041	C++
==>	libcef.dll!content::`anonymous namespace'::IntentionallyCrashBrowserForUnusableGpuProcess() Line 448	C++
 	libcef.dll!content::GpuDataManagerImplPrivate::FallBackToNextGpuMode() Line 1764	C++
 	libcef.dll!content::GpuDataManagerImpl::FallBackToNextGpuMode() Line 374	C++
 	libcef.dll!content::GpuProcessHost::RecordProcessCrash() Line 1382	C++
 	libcef.dll!content::GpuProcessHost::OnProcessLaunchFailed(int error_code) Line 984	C++
 	libcef.dll!content::BrowserChildProcessHostImpl::OnProcessLaunchFailed(int error_code) Line 609	C++
 	libcef.dll!content::ChildProcessLauncher::Notify(content::internal::ChildProcessLauncherHelper::Process process, unsigned long last_error, int error_code) Line 183	C++
 	libcef.dll!content::internal::ChildProcessLauncherHelper::PostLaunchOnClientThread(content::internal::ChildProcessLauncherHelper::Process process, unsigned long last_error, int error_code) Line 254	C++
 	
```