### PR TITLE
Add fflush to ConsoleApplication 2.0 metrics csv

### DIFF
--- a/PresentMon/CsvOutput.cpp
+++ b/PresentMon/CsvOutput.cpp
@@ -307,6 +307,10 @@ void WriteCsvHeader<FrameMetrics>(FILE* fp)
         fwprintf(fp, L",FrameId");
     }
     fwprintf(fp, L"\n");
+
+    if (args.mCSVOutput == CSVOutput::Stdout) {
+        fflush(fp);
+    }
 }
 
 template<>
@@ -395,6 +399,10 @@ void WriteCsvRow<FrameMetrics>(
         fwprintf(fp, L",%u", p.FrameId);
     }
     fwprintf(fp, L"\n");
+
+    if (args.mCSVOutput == CSVOutput::Stdout) {
+        fflush(fp);
+    }
 }
 
 template<typename FrameMetricsT>


### PR DESCRIPTION
Flushes were accidentally removed at some point.  v2.0.1 added them back in, but only for the --use_v1_metrics CSV.  This change adds them back in for the default CSV as well.

Fixes #232