### PR TITLE
Set deferral time limit for IPM

### DIFF
--- a/IntelPresentMon/PresentMonService/RealtimePresentMonSession.cpp
+++ b/IntelPresentMon/PresentMonService/RealtimePresentMonSession.cpp
@@ -171,6 +171,11 @@ PM_STATUS RealtimePresentMonSession::StartTraceSession() {
         }
     }
 
+    // Set deferral time limit to 2 seconds
+    if (trace_session_.mPMConsumer->mDeferralTimeLimit == 0) {
+        trace_session_.mPMConsumer->mDeferralTimeLimit = trace_session_.mTimestampFrequency.QuadPart * 2;
+    }
+
     // Start the consumer and output threads
     StartConsumerThread(trace_session_.mTraceHandle);
     StartOutputThread();


### PR DESCRIPTION
The deferral time limit was not being set for real time captures which was causing deferred presents to incorrectly be classified as lost when cleaning up "stale deferred frames" in CompletePresent.