### PR TITLE
Fix WM_HOTKEY handling to prevent unintended message propagation

### DIFF
--- a/PresentMon/MainThread.cpp
+++ b/PresentMon/MainThread.cpp
@@ -150,7 +150,7 @@ static LRESULT CALLBACK HandleWindowMessage(HWND hWnd, UINT uMsg, WPARAM wParam,
     case WM_HOTKEY:
         if (gHotkeyIgnoreCount > 0) {
             gHotkeyIgnoreCount -= 1;
-            break;
+            return 0;
         }
 
         if (IsRecording()) {


### PR DESCRIPTION
## Description
When `gHotkeyIgnoreCount > 0`, the `WM_HOTKEY` message handler breaks out of the switch statement instead of returning early. This allows the message to propagate to `DefWindowProc`, potentially triggering unintended hotkey behavior in other applications (e.g., if the same hotkey is registered elsewhere).

## Solution
Replacing the `break` statement with `return 0` in the `WM_HOTKEY` ignore block ensures the message is marked as "handled," preventing further propagation.