### PR TITLE
Fix Process Handle Leak on Reused Process IDs

### DIFF
--- a/PresentMon/OutputThread.cpp
+++ b/PresentMon/OutputThread.cpp
@@ -159,6 +159,10 @@ static void ProcessProcessEvent(
 
         if (!pr.second) {
             HandleTerminatedProcess(info);
+            if (info->mHandle != NULL) {
+                CloseHandle(info->mHandle);
+                info->mHandle = NULL;
+            }
         }
 
         info->mHandle          = NULL;


### PR DESCRIPTION
## Description
When a new process start event was received for an existing Process ID (PID), the existing `ProcessInfo` handle `(mHandle)` was not closed, leading to handle leaks and potential resource exhaustion.

## Solution
Closed the existing process handle in `ProcessProcessEvent` before reinitializing `ProcessInfo` for reused PIDs and Added checks to safely close `mHandle` when a process start event overlaps with a previously tracked PID.