### PR TITLE
allow specifying middleware path in sample client & better wrapper errs

### DIFF
--- a/IntelPresentMon/CommonUtilities/cli/CliFramework.h
+++ b/IntelPresentMon/CommonUtilities/cli/CliFramework.h
@@ -170,6 +170,10 @@ namespace pmon::util::cli
 		{
 			return !bool(*this);
 		}
+		const T* operator->() const
+		{
+			return &data_;
+		}
 		std::optional<T> AsOptional() const
 		{
 			if (*this) {

--- a/IntelPresentMon/PresentMonAPIWrapperCommon/Exception.cpp
+++ b/IntelPresentMon/PresentMonAPIWrapperCommon/Exception.cpp
@@ -1,5 +1,6 @@
 #include "Exception.h"
 #include "EnumMap.h"
+#include "../Interprocess/source/metadata/EnumStatus.h"
 #include <format>
 
 namespace pmapi
@@ -19,7 +20,24 @@ namespace pmapi
                 str.narrowSymbol, int(err), str.narrowName, str.narrowDescription);
         }
         catch (...) {
-            return std::format("{} | Unknown error code [{}]", message, int(err));
+            // we usually end up here trying to translate a PM_STATUS code before we have introspection access
+            // fallback to a static lookup generated based on the known set of codes at wrapper compile time
+            bool descriptionAvailable = false;
+            const char* frag = nullptr;
+            const char* name = nullptr;
+            const char* desc = nullptr;
+            switch (err) {
+#define X_STATUS_(enum_name_fragment, key_frag_, name_, short_name, desc_) \
+                case PM_STATUS_##key_frag_: frag = #key_frag_; name = name_; desc = desc_; descriptionAvailable = true; break;
+                ENUM_KEY_LIST_STATUS(X_STATUS_)
+#undef X_STATUS_
+            }
+            if (descriptionAvailable) {
+                return std::format("{} | Error: {} ({}) {}: {}", message, frag, int(err), name, desc);
+            }
+            else {
+                return std::format("{} | Unknown error code [{}]", message, int(err));
+            }
         }
     }
 }

--- a/IntelPresentMon/SampleClient/CliOptions.h
+++ b/IntelPresentMon/SampleClient/CliOptions.h
@@ -9,8 +9,7 @@ namespace clio
 	using namespace pmon::util::cli;
 	struct Options : public OptionsBase<Options>
 	{
-		Option<std::string> controlPipe{ this, "--control-pipe", "", "Name of the named pipe to use for the client-service control channel" };
-		Option<std::string> introNsm{ this, "--intro-nsm", "", "Name of the NSM used for introspection data" };
+	private: Group gm_{ this, "Mode", "Choose sample mode" }; public:
 		Flag introspectionSample{ this, "--introspection-sample", "Example of how to view availability of all system metrics via introspection" };
 		Flag dynamicQuerySample{ this, "--dynamic-query-sample", "Example of how to use a dynamic query to poll metric data" };
 		Flag frameQuerySample{ this, "--frame-query-sample", "Example of how to use a frame query to consume raw frame data" };
@@ -19,14 +18,19 @@ namespace clio
 		Flag wrapperStaticQuerySample{ this, "--wrapper-static-query-sample", "Example of using the wrapper to poll static metric data" };
 		Flag genCsv{ this, "--gen-csv", "Example of creating a csv file from consumed raw frame data" };
 		Flag addGPUMetric{ this, "--add-gpu-metric", "Example of how to search for an available GPU metric and add it to a dynamic query" };
+		Option<int> logDemo{ this, "--log-demo", 0, "Demos of log utility features" };
+		Option<int> diagDemo{ this, "--diag-demo", 0, "Demos of debug diagnostic layer interface" };
+	private: Group gc_{ this, "Connection", "Control client connection" }; public:
+		Option<std::string> controlPipe{ this, "--control-pipe", "", "Name of the named pipe to use for the client-service control channel" };
+		Option<std::string> introNsm{ this, "--intro-nsm", "", "Name of the NSM used for introspection data" };
+		Option<std::string> middlewareDllPath{ this, "--middleware-dll-path", "", "Override middleware DLL path discovery with custom path" };
+	private: Group gs_{ this, "Sampling", "Control sampling / targeting behavior" }; public:
 		Option<double> metricOffset{ this, "--metric-offset", 1000., "Offset from top for frame data. Used in --dynamic-query-sample" };
 		Option<double> windowSize{ this, "--window-size", 2000., "Window size used for metrics calculation. Used in --dynamic-query-sample" };
 		Option<unsigned int> processId{ this, "--process-id", 0, "Process Id to use for polling or frame data capture" };
 		Option<std::string> processName{ this, "--process-name", "", "Name of process to use for polling or frame data capture" };
 		Option<std::string> metric{ this, "--metric", "", "PM_METRIC, ex. PM_METRIC_PRESENTED_FPS" };
-		Option<int> logDemo{ this, "--log-demo", 0, "Demos of log utility features" };
-		Option<int> diagDemo{ this, "--diag-demo", 0, "Demos of debug diagnostic layer interface" };
-
+	private: Group gl_{ this, "Logging", "Control logging behavior" }; public:
 		Option<log::Level> logLevel{ this, "--log-level", log::Level::Error, "Severity to log at", CLI::CheckedTransformer{ log::GetLevelMapNarrow(), CLI::ignore_case } };
 		Option<log::Level> logTraceLevel{ this, "--log-trace-level", log::Level::Error, "Severity to print stacktrace at", CLI::CheckedTransformer{ log::GetLevelMapNarrow(), CLI::ignore_case } };
 		Flag logTraceExceptions{ this, "--log-trace-exceptions", "Add stack trace to all thrown exceptions (including SEH exceptions)" };

--- a/IntelPresentMon/SampleClient/SampleClient.args.json
+++ b/IntelPresentMon/SampleClient/SampleClient.args.json
@@ -3,116 +3,16 @@
   "Id": "79fe382a-c29c-4c32-a028-b8d1abdf51b0",
   "Items": [
     {
-      "Id": "04b29279-a10b-4fba-b127-1816b6a05c21",
-      "Command": "--log-demo 0"
-    },
-    {
-      "Id": "178328e1-cee6-4ec9-898d-470073f9bc88",
-      "Command": "--log-demo 1"
-    },
-    {
-      "Id": "3c5a7c74-4cc0-4251-8cef-a3c5dc135a1d",
-      "Command": "--log-demo 17"
-    },
-    {
-      "Id": "bb813e93-75af-46b5-9d4f-d4051007e9e8",
-      "Command": "--log-demo 18"
-    },
-    {
-      "Id": "c1c14433-3ec1-4fc3-9b3b-70b6580bc080",
-      "Command": "--log-allow-list \"black.txt\""
-    },
-    {
-      "Id": "6248d4d3-1a61-499d-84e8-83be773d62af",
-      "Command": "--log-trace-level info"
-    },
-    {
-      "Id": "edbe1209-2ed7-4381-8cd4-5eb6fe9e966a",
-      "Command": "--log-level info"
-    },
-    {
-      "Id": "afc8e7e1-be12-46f8-aed2-d8c09c4a5cfa",
-      "Command": "--log-allow-list bbb"
-    },
-    {
-      "Id": "b8b13731-0ee5-48c0-bee5-216f8ef884d5",
-      "Command": "--log-deny-list aaa"
-    },
-    {
-      "Id": "78f46a64-b667-4d83-91f5-48b1332ca0c0",
-      "Command": "--diag-demo 32612"
-    },
-    {
-      "Id": "edf9d064-e8f2-4c3c-8ab3-a70ae989a245",
-      "Command": "--log-demo 29916"
-    },
-    {
-      "Id": "78f46a64-b667-4d83-91f5-48b1332ca0c0",
-      "Command": "--diag-demo 32612"
-    },
-    {
-      "Id": "edf9d064-e8f2-4c3c-8ab3-a70ae989a245",
-      "Command": "--log-demo 29916"
-    },
-    {
-      "Id": "de172ca4-f013-4f7c-99e2-5b93c03c4ec5",
-      "Command": "--log-demo 19"
-    },
-    {
-      "Id": "55055cc7-7bbb-4db3-8f8f-27f1b5994bd2",
-      "Command": "--wrapper-static-query-sample"
-    },
-    {
-      "Id": "aec2f3f0-8119-42e8-a154-f0362d3a79bc",
-      "Command": "--gen-csv"
-    },
-    {
-      "Id": "fdccba8e-f10c-42b0-a1d0-b71cfa1fe849",
-      "Command": "--add-gpu-metric"
-    },
-    {
-      "Id": "68093de8-734b-45c0-b00c-718b665cbb85",
-      "Command": "--check-metric-sample"
-    },
-    {
-      "Id": "905a2f3c-5d4d-4d8e-becd-182e5078fba4",
-      "Command": "--metric PM_METRIC_GPU_MEM_MAX_BANDWIDTH"
-    },
-    {
-      "Id": "c3af5374-64e9-40e0-ae04-a5e3142e0bc7",
-      "Command": "--frame-query-sample"
-    },
-    {
-      "Id": "6c0c832e-fb7b-4738-afa4-a71bc23235e9",
-      "Command": "--introspection-sample"
-    },
-    {
-      "Id": "e4c5c9a2-dee7-4185-afe1-51c4e6c3281b",
-      "Command": "--dynamic-query-sample"
-    },
-    {
-      "Id": "ef857247-b1e3-491c-931a-c1be6924dd90",
+      "Id": "91c5d42b-2da5-4d40-96bf-4ba9e1cce907",
       "Command": "--help"
     },
     {
-      "Id": "4d012d46-c606-4e44-91a4-8bfa0865cfbc",
-      "Command": "--process-name Valley.exe"
+      "Id": "e8bc0b0d-87c9-4465-b3df-ece2942c05a3",
+      "Command": "--introspection-sample"
     },
     {
-      "Id": "90f7b819-b9e5-4f19-a315-186c1affaa5d",
-      "Command": "--control-pipe \\\\.\\pipe\\igs"
-    },
-    {
-      "Id": "b37ef2ea-3c9c-4929-8f5b-29ba539674e2",
-      "Command": "--intro-nsm Global\\pm2_bip_shm_igs"
-    },
-    {
-      "Id": "7f6ffa38-2a9a-480c-a811-a10c76820b74",
-      "Command": "--view-available-metrics"
-    },
-    {
-      "Id": "df9b72a0-fe65-4819-9bef-82142ab661e1",
-      "Command": "--metric-offset 1080"
+      "Id": "2cf4c62a-0c43-4a7f-a686-8dc38ffc3868",
+      "Command": "--middleware-dll-path .\\PresentMonAPI2.dll"
     }
   ]
 }

--- a/IntelPresentMon/SampleClient/SampleClient.cpp
+++ b/IntelPresentMon/SampleClient/SampleClient.cpp
@@ -21,6 +21,7 @@
 
 #include "../PresentMonAPIWrapper/PresentMonAPIWrapper.h"
 #include "../PresentMonAPIWrapper/FixedQuery.h"
+#include "../PresentMonAPI2Loader/Loader.h"
 #include "Utils.h"
 #include "DynamicQuerySample.h"
 #include "FrameQuerySample.h"
@@ -55,6 +56,10 @@ int main(int argc, char* argv[])
             return -1;
         }
 
+        if (opt.middlewareDllPath) {
+            pmLoaderSetPathToMiddlewareDll_(opt.middlewareDllPath->c_str());
+        }
+
         // determine requested activity
         if (opt.introspectionSample ^ opt.dynamicQuerySample ^ opt.frameQuerySample ^ opt.checkMetricSample ^ opt.wrapperStaticQuerySample ^ opt.metricListSample) {
             std::unique_ptr<pmapi::Session> pSession;
@@ -85,12 +90,13 @@ int main(int argc, char* argv[])
             }
         }
         else {
-            std::cout << "SampleClient supports one action at a time. Select one of:\n";
+            std::cout << "SampleClient supports one action at a time. For example:\n";
             std::cout << "--introspection-sample\n";
             std::cout << "--wrapper-static-query-sample\n";
             std::cout << "--dynamic-query-sample [--process-id id | --process-name name.exe] [--add-gpu-metric]\n";
             std::cout << "--frame-query-sample [--process-id id | --process-name name.exe]  [--gen-csv]\n";
             std::cout << "--check-metric-sample --metric PM_METRIC_*\n";
+            std::cout << "Use --help to see the full list of commands and configuration options available\n";
             return -1;
         }
     }


### PR DESCRIPTION
enabling sample client to be used with presentmon servers other than the default globally installed service after the new loader update