### PR TITLE
Updating CB Size

### DIFF
--- a/PresentData/PresentMonTraceConsumer.cpp
+++ b/PresentData/PresentMonTraceConsumer.cpp
@@ -21,7 +21,7 @@
 #include <stdlib.h>
 #include <unordered_set>
 
-static constexpr int PRESENTEVENT_CIRCULAR_BUFFER_SIZE = 1024;
+static constexpr int PRESENTEVENT_CIRCULAR_BUFFER_SIZE = 4096;
 
 static uint32_t gNextFrameId = 1;
 


### PR DESCRIPTION
Current CB size starts dropping frames at greater than 700 fps. Increasing size to accommodate framerates up to 1000 FPS.