### PR TITLE
feat: Add build script to automate setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: PresentMon CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+
+    - name: Setup MSVC
+      uses: microsoft/setup-msvc@v1.1
+
+    - name: Define CEF Download URL
+      id: cef-url
+      run: echo "CEF_URL=https://cef-builds.spotifycdn.com/cef_binary_136.1.6%2Bg1ac1b14%2Bchromium-136.0.7103.114_windows64_minimal.tar.bz2" >> $env:GITHUB_ENV
+
+    - name: Cache CEF
+      id: cache-cef
+      uses: actions/cache@v4
+      with:
+        path: C:\cef
+        key: ${{ runner.os }}-cef-v136
+
+    - name: Download and extract CEF
+      if: steps.cache-cef.outputs.cache-hit != 'true'
+      shell: pwsh
+      run: |
+        echo "Downloading CEF from ${{ env.CEF_URL }}"
+        Invoke-WebRequest -Uri ${{ env.CEF_URL }} -OutFile cef.tar.bz2
+
+        New-Item -ItemType Directory -Force -Path C:\cef_temp
+
+        tar -xjf cef.tar.bz2 -C C:\cef_temp
+
+        $extractedDir = Get-ChildItem -Path C:\cef_temp | Select-Object -First 1
+        Move-Item -Path $extractedDir.FullName\* -Destination C:\cef
+
+        Remove-Item -Path C:\cef_temp, cef.tar.bz2 -Recurse
+
+    - name: Run build script
+      shell: cmd
+      run: |
+        build.bat C:\cef

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -14,6 +14,18 @@ Note: if you only want to build the PresentData library, or the PresentMon Conso
 you only need Visual Studio.  Ignore the other build and source dependency instructions and build
 `PresentData\PresentData.vcxproj` or `PresentMon\ConsoleApplication.sln`.
 
+## Automated Build Script
+
+For convenience, a batch script `build.bat` is provided to automate the entire build process. This script will perform all the steps described below, including installing vcpkg dependencies, building CEF, building the web assets, and building the final PresentMon solution.
+
+To use the script:
+1. Open a Command Prompt or PowerShell terminal.
+2. Run the script from the root of the repository: `.\build.bat`
+3. The script will pause and ask you to provide the full path to your downloaded and extracted CEF (Chromium Embedded Framework) directory.
+4. The script will attempt to create and install a test certificate, which requires administrator privileges. It is recommended to run the script in a terminal with Administrator rights.
+
+The manual steps are still documented below if you prefer to execute the build process step-by-step.
+
 ## Install Source Dependencies
 
 1. Download and install *vcpkg*, which will be used to obtain source package dependencies during the build:

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,155 @@
+@echo off
+setlocal
+
+echo =================================================================
+echo  PresentMon Build Script
+echo =================================================================
+echo.
+echo This script will automate the build process for PresentMon.
+echo It follows the instructions from BUILDING.md.
+echo.
+echo Please ensure you have the following prerequisites installed:
+echo   - Visual Studio 2022 (with C++ workload)
+echo   - CMake
+echo   - Node.js / NPM
+echo   - WiX toolset v3
+echo.
+echo =================================================================
+echo.
+
+REM Function to check for errors
+:check_error
+if %errorlevel% neq 0 (
+    echo.
+    echo ***************************************************************
+    echo  An error occurred. Aborting script.
+    echo ***************************************************************
+    exit /b %errorlevel%
+)
+goto :eof
+
+
+echo [1/6] Installing vcpkg dependencies...
+echo -----------------------------------------------------------------
+if not exist "build\vcpkg\vcpkg.exe" (
+    echo Cloning vcpkg repository...
+    git clone https://github.com/Microsoft/vcpkg.git build\vcpkg
+    call :check_error
+
+    echo Bootstrapping vcpkg...
+    call build\vcpkg\bootstrap-vcpkg.bat
+    call :check_error
+) else (
+    echo vcpkg already found. Skipping clone and bootstrap.
+)
+
+echo Integrating vcpkg...
+call build\vcpkg\vcpkg.exe integrate install
+call :check_error
+
+echo Installing vcpkg packages...
+call build\vcpkg\vcpkg.exe install
+call :check_error
+echo -----------------------------------------------------------------
+echo.
+
+
+echo [2/6] Building Chromium Embedded Framework (CEF)
+echo -----------------------------------------------------------------
+if "%~1"=="" (
+  set /p "CEF_DIR=Please enter the full path to your extracted CEF directory (e.g., C:\cef_133): "
+) else (
+  set "CEF_DIR=%~1"
+  echo Using CEF directory from command line argument: %CEF_DIR%
+)
+
+if not exist "%CEF_DIR%\CMakeLists.txt" (
+    echo Error: CEF directory not found or invalid at '%CEF_DIR%'.
+    echo Please download and extract the CEF minimal distribution from
+    echo https://cef-builds.spotifycdn.com/index.html
+    exit /b 1
+)
+
+echo Building CEF (Debug and Release)...
+cmake -G "Visual Studio 17 2022" -A x64 -DUSE_SANDBOX=OFF -S "%CEF_DIR%" -B "%CEF_DIR%\build"
+call :check_error
+
+cmake --build "%CEF_DIR%\build" --config Debug
+call :check_error
+
+cmake --build "%CEF_DIR%\build" --config Release
+call :check_error
+
+echo Pulling CEF build outputs into the project...
+call IntelPresentMon\AppCef\Batch\pull-cef.bat "%CEF_DIR%"
+call :check_error
+echo -----------------------------------------------------------------
+echo.
+
+
+echo [3/6] Building Web Asset Dependencies (NPM)
+echo -----------------------------------------------------------------
+pushd IntelPresentMon\AppCef\ipm-ui-vue
+echo Installing npm packages...
+npm ci
+call :check_error
+
+echo Building web assets...
+npm run build
+call :check_error
+popd
+echo -----------------------------------------------------------------
+echo.
+
+
+echo [4/6] Creating and Installing Test Certificate
+echo -----------------------------------------------------------------
+echo This step requires Administrator privileges.
+echo If the script fails here, please re-run it from an
+echo Administrator command prompt.
+echo.
+makecert -r -pe -n "CN=Test Certificate - For Internal Use Only" -ss PrivateCertStore testcert.cer > nul 2>&1
+if %errorlevel% neq 0 (
+    echo WARNING: Failed to create certificate. This may be because
+    echo          'makecert.exe' is not in your PATH or you are not
+    echo          running as an Administrator. The Release build might
+    echo          fail to run.
+) else (
+    certutil -addstore root testcert.cer
+    call :check_error
+    echo Certificate created and installed successfully.
+)
+echo -----------------------------------------------------------------
+echo.
+
+
+echo [5/6] Building PresentMon Solution
+echo -----------------------------------------------------------------
+echo Building Debug configuration...
+msbuild /p:Platform=x64,Configuration=Debug PresentMon.sln
+call :check_error
+
+echo Building Release configuration...
+msbuild /p:Platform=x64,Configuration=Release PresentMon.sln
+call :check_error
+echo -----------------------------------------------------------------
+echo.
+
+
+echo [6/6] Build complete!
+echo =================================================================
+echo.
+echo Binaries can be found in the 'build\Debug' and 'build\Release'
+echo directories.
+echo.
+echo To run the application:
+echo  - Start the service (as Administrator):
+echo    sc.exe create PresentMonService binPath=\"%cd%\build\Release\PresentMonService.exe\"
+echo    sc.exe start PresentMonService
+echo  - Run the capture app from its directory:
+echo    cd build\Release
+echo    PresentMon.exe
+echo.
+echo =================================================================
+
+endlocal


### PR DESCRIPTION
This commit introduces a new Windows batch script, `build.bat`, to fully automate the build process described in `BUILDING.md`.

The script handles:
- Cloning and bootstrapping vcpkg
- Installing required vcpkg packages
- Building the Chromium Embedded Framework (CEF) from a user-provided directory
- Installing NPM dependencies for the UI
- Creating and installing a test certificate
- Building the main Visual Studio solution

This script significantly simplifies the setup for new and existing developers, reducing the chance of manual errors.

The `BUILDING.md` file has also been updated to document the usage of this new script.