### PR TITLE
NVTraceConsumer: only apply flipDelay when vsync off

### DIFF
--- a/PresentData/PresentMonTraceConsumer.cpp
+++ b/PresentData/PresentMonTraceConsumer.cpp
@@ -965,9 +965,6 @@ void PMTraceConsumer::HandleDXGKEvent(EVENT_RECORD* pEventRecord)
             auto present = FindPresentBySubmitSequence(submitSequence);
             if (present != nullptr) {
 
-                // Apply Nvidia FlipDelay, if any, to the presentEvent
-                mNvTraceConsumer.ApplyFlipDelay(present.get(), hdr.ThreadId);
-
                 // Complete the GPU tracking for this frame.
                 //
                 // For some present modes (e.g., Hardware_Legacy_Flip) this may be
@@ -991,6 +988,8 @@ void PMTraceConsumer::HandleDXGKEvent(EVENT_RECORD* pEventRecord)
                         if (FlipEntryStatusAfterFlip != (uint32_t) Microsoft_Windows_DxgKrnl::FlipEntryStatus::FlipWaitHSync) {
 
                             SetScreenTime(present, hdr.TimeStamp.QuadPart + present->FlipDelay);
+                            // Apply Nvidia FlipDelay, if any, to the presentEvent
+                            mNvTraceConsumer.ApplyFlipDelay(present.get(), hdr.ThreadId);
 
                             if (present->PresentMode == PresentMode::Hardware_Legacy_Flip) {
                                 CompletePresent(present);


### PR DESCRIPTION
Sometimes, when vsync is on, flipDelay could be non-zero even DLSS FrameGen is disabled. In this situation, flipDelay should not be considered.

FlipDelay should only be applied if FlipEntryStatusAfterFlip is not FlipWaitVSync nor FlipWaitHSync.