### PR TITLE
Prevent pruning of DWM.exe swap chains with address 0x0

### DIFF
--- a/PresentMon/OutputThread.cpp
+++ b/PresentMon/OutputThread.cpp
@@ -4,10 +4,13 @@
 
 #include "PresentMon.hpp"
 #include "../IntelPresentMon/CommonUtilities/Math.h"
+#include "../IntelPresentMon/CommonUtilities/str/String.h"
 
 #include <algorithm>
 #include <shlwapi.h>
 #include <thread>
+
+using namespace pmon;
 
 static std::thread gThread;
 static bool gQuit = false;
@@ -840,13 +843,8 @@ static void PruneOldSwapChainData(
         auto processInfo = &pair.second;
 
         // Check if this is DWM process
-        bool isDwmProcess = false;
-        std::wstring processName = processInfo->mModuleName;
-        std::transform(processName.begin(), processName.end(), processName.begin(),
-            [](wchar_t c) { return (wchar_t) ::towlower(c); });
-        if (processName.find(L"dwm.exe") != std::wstring::npos) {
-            isDwmProcess = true;
-        }
+        const bool isDwmProcess =
+            util::str::ToLower(processInfo->mModuleName).contains(L"dwm.exe");
 
         for (auto ii = processInfo->mSwapChain.begin(), ie = processInfo->mSwapChain.end(); ii != ie; ) {
             auto swapChainAddress = ii->first;


### PR DESCRIPTION
Pruning DWM.exe swap chains with address 0x0 caused inconsistent test results because these swap chains are reused by the Desktop Window Manager for desktop composition. Removing them prematurely led to missing or unexpected data during unit and integration tests, especially in scenarios where DWM activity is infrequent. By excluding DWM.exe swap chains with address 0x0 from pruning, we ensure stable and predictable test outcomes.