### PR TITLE
Fix/nvml struct

### DIFF
--- a/IntelPresentMon/CommonUtilities/ref/GeneratedReflectionHelpers.h
+++ b/IntelPresentMon/CommonUtilities/ref/GeneratedReflectionHelpers.h
@@ -1,6 +1,11 @@
 ﻿#pragma once
-#include <string>
 #include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <format>
+#include <sstream>
+#include <string>
+#include <type_traits>
 #include "GeneratedReflection.h"
 
 namespace pmon::util::ref::gen

--- a/IntelPresentMon/CommonUtilities/ref/gen/GeneratedReflection.h
+++ b/IntelPresentMon/CommonUtilities/ref/gen/GeneratedReflection.h
@@ -326,8 +326,8 @@ namespace pmon::util::ref::gen
 			const auto& s = *static_cast<const nvmlMemory_t*>(pStruct);
 			std::ostringstream oss;
 			oss << std::boolalpha << "struct nvmlMemory_t {"
-				<< " .free = " << s.free
 				<< " .total = " << s.total
+				<< " .free = " << s.free
 				<< " .used = " << s.used
 				<< " }";
 			return oss.str();

--- a/IntelPresentMon/ControlLib/nvml/NvmlTelemetryProvider.cpp
+++ b/IntelPresentMon/ControlLib/nvml/NvmlTelemetryProvider.cpp
@@ -122,7 +122,7 @@ namespace pmon::tel::nvml
             if (pMemoryInfo == nullptr) {
                 return (uint64_t)0;
             }
-            return GetLegacyTotalMemoryBytes_(*pMemoryInfo);
+            return GetTotalMemoryBytes_(*pMemoryInfo);
         }
         case PM_METRIC_GPU_MEM_USED:
         {
@@ -141,7 +141,7 @@ namespace pmon::tel::nvml
                 return 0.0;
             }
 
-            const auto totalBytes = GetLegacyTotalMemoryBytes_(*pMemoryInfo);
+            const auto totalBytes = GetTotalMemoryBytes_(*pMemoryInfo);
             if (totalBytes == 0) {
                 return 0.0;
             }
@@ -160,9 +160,9 @@ namespace pmon::tel::nvml
         (void)metricId;
     }
 
-    uint64_t NvmlTelemetryProvider::GetLegacyTotalMemoryBytes_(const nvmlMemory_t& memoryInfo) noexcept
+    uint64_t NvmlTelemetryProvider::GetTotalMemoryBytes_(const nvmlMemory_t& memoryInfo) noexcept
     {
-        return (uint64_t)memoryInfo.free;
+        return (uint64_t)memoryInfo.total;
     }
 
     bool NvmlTelemetryProvider::TryInitializeDevice_(DeviceState_& device, nvmlDevice_t handle) const
@@ -232,7 +232,7 @@ namespace pmon::tel::nvml
         }
 
         if (const auto* pMemoryInfo = PollMemoryInfoEndpoint_(device, requestQpc)) {
-            const auto totalBytes = GetLegacyTotalMemoryBytes_(*pMemoryInfo);
+            const auto totalBytes = GetTotalMemoryBytes_(*pMemoryInfo);
             if (totalBytes != 0) {
                 caps.Set(PM_METRIC_GPU_MEM_SIZE, 1);
                 caps.Set(PM_METRIC_GPU_MEM_USED, 1);

--- a/IntelPresentMon/ControlLib/nvml/NvmlTelemetryProvider.h
+++ b/IntelPresentMon/ControlLib/nvml/NvmlTelemetryProvider.h
@@ -39,7 +39,7 @@ namespace pmon::tel::nvml
         };
 
         static void ValidateScalarMetricIndex_(PM_METRIC metricId, uint32_t arrayIndex);
-        static uint64_t GetLegacyTotalMemoryBytes_(const nvmlMemory_t& memoryInfo) noexcept;
+        static uint64_t GetTotalMemoryBytes_(const nvmlMemory_t& memoryInfo) noexcept;
 
         bool TryInitializeDevice_(DeviceState_& device, nvmlDevice_t handle) const;
         ipc::MetricCapabilities BuildCapsForDevice_(DeviceState_& device) const;

--- a/IntelPresentMon/ControlLib/nvml/nvml.h
+++ b/IntelPresentMon/ControlLib/nvml/nvml.h
@@ -111,8 +111,8 @@ struct nvmlPciInfo_t {
 };
 
 struct nvmlMemory_t {
-	unsigned long long free;
 	unsigned long long total;
+	unsigned long long free;
 	unsigned long long used;
 };
 


### PR DESCRIPTION
Undo nvAPI mismatch workaround, make header dependency explicit/order independent (GHCP-suggested edits from granular telemetry PR).