### PR TITLE
Add Game Experience overlay loadout preset

### DIFF
--- a/IntelPresentMon/AppCef/ipm-ui-vue/presets/preset-2.json
+++ b/IntelPresentMon/AppCef/ipm-ui-vue/presets/preset-2.json
@@ -8,7 +8,7 @@
          "key": 0,
          "metrics": [
             {
-               "key": 8,
+               "key": 3,
                "metric": {
                   "metricId": 3,
                   "arrayIndex": 0,
@@ -50,7 +50,7 @@
          "key": 1,
          "metrics": [
             {
-               "key": 3,
+               "key": 1,
                "metric": {
                   "metricId": 12,
                   "arrayIndex": 0,
@@ -92,7 +92,7 @@
          "key": 2,
          "metrics": [
             {
-               "key": 11,
+               "key": 0,
                "metric": {
                   "metricId": 12,
                   "arrayIndex": 0,
@@ -114,7 +114,7 @@
                "axisAffinity": 0
             },
             {
-               "key": 0,
+               "key": 2,
                "metric": {
                   "metricId": 12,
                   "arrayIndex": 0,
@@ -122,9 +122,9 @@
                   "statId": 5
                },
                "lineColor": {
-                  "r": 19,
-                  "g": 243,
-                  "b": 30,
+                  "r": 255,
+                  "g": 100,
+                  "b": 122,
                   "a": 0.8627450980392157
                },
                "fillColor": {
@@ -145,7 +145,7 @@
             "name": "Line",
             "range": [
                0,
-               150
+               200
             ],
             "rangeRight": [
                0,
@@ -202,17 +202,17 @@
          "key": 3,
          "metrics": [
             {
-               "key": 12,
+               "key": 8,
                "metric": {
-                  "metricId": 28,
+                  "metricId": 87,
                   "arrayIndex": 0,
                   "deviceId": null,
                   "statId": 1
                },
                "lineColor": {
-                  "r": 249,
+                  "r": 100,
                   "g": 255,
-                  "b": 100,
+                  "b": 255,
                   "a": 0.8627450980392157
                },
                "fillColor": {
@@ -224,17 +224,123 @@
                "axisAffinity": 0
             },
             {
-               "key": 13,
+               "key": 9,
                "metric": {
-                  "metricId": 31,
+                  "metricId": 14,
                   "arrayIndex": 0,
                   "deviceId": null,
                   "statId": 1
                },
                "lineColor": {
-                  "r": 193,
-                  "g": 174,
+                  "r": 245,
+                  "g": 255,
+                  "b": 0,
+                  "a": 0.8627450980392157
+               },
+               "fillColor": {
+                  "r": 57,
+                  "g": 210,
+                  "b": 250,
+                  "a": 0.09803921568627451
+               },
+               "axisAffinity": 0
+            }
+         ],
+         "widgetType": 0,
+         "height": 80,
+         "vDivs": 4,
+         "hDivs": 40,
+         "showBottomAxis": false,
+         "graphType": {
+            "name": "Line",
+            "range": [
+               0,
+               150
+            ],
+            "rangeRight": [
+               0,
+               150
+            ],
+            "binCount": 40,
+            "countRange": [
+               0,
+               1000
+            ],
+            "autoLeft": true,
+            "autoRight": true,
+            "autoCount": false
+         },
+         "gridColor": {
+            "r": 47,
+            "g": 120,
+            "b": 190,
+            "a": 0.1568627450980392
+         },
+         "dividerColor": {
+            "r": 57,
+            "g": 126,
+            "b": 150,
+            "a": 0.8627450980392157
+         },
+         "backgroundColor": {
+            "r": 0,
+            "g": 0,
+            "b": 0,
+            "a": 0
+         },
+         "borderColor": {
+            "r": 0,
+            "g": 0,
+            "b": 0,
+            "a": 0
+         },
+         "textColor": {
+            "r": 242,
+            "g": 242,
+            "b": 242,
+            "a": 1
+         },
+         "textSize": 11
+      },
+      {
+         "key": 4,
+         "metrics": [
+            {
+               "key": 0,
+               "metric": {
+                  "metricId": 30,
+                  "arrayIndex": 0,
+                  "deviceId": 0,
+                  "statId": 1,
+                  "desiredUnitId": 0
+               },
+               "lineColor": {
+                  "r": 125,
+                  "g": 149,
                   "b": 255,
+                  "a": 0.8627450980392157
+               },
+               "fillColor": {
+                  "r": 57,
+                  "g": 210,
+                  "b": 250,
+                  "a": 0.09803921568627451
+               },
+               "axisAffinity": 0
+            },
+            {
+               "key": 4,
+               "metric": {
+                  "metricId": 33,
+                  "arrayIndex": 0,
+                  "deviceId": 0,
+                  "statId": 1,
+                  "desiredUnitId": 0
+               },
+               "lineColor": {
+                  "r": 24,
+                  "g": 255,
+                  "b": 0,
                   "a": 0.8627450980392157
                },
                "fillColor": {
@@ -276,11 +382,111 @@
             "b": 190,
             "a": 0.1568627450980392
          },
-         "valueTextColor": {
-            "r": 34,
-            "g": 210,
-            "b": 250,
+         "dividerColor": {
+            "r": 57,
+            "g": 126,
+            "b": 150,
             "a": 0.8627450980392157
+         },
+         "backgroundColor": {
+            "r": 0,
+            "g": 0,
+            "b": 0,
+            "a": 0
+         },
+         "borderColor": {
+            "r": 0,
+            "g": 0,
+            "b": 0,
+            "a": 0
+         },
+         "textColor": {
+            "r": 242,
+            "g": 242,
+            "b": 242,
+            "a": 1
+         },
+         "textSize": 11
+      },
+      {
+         "key": 5,
+         "metrics": [
+            {
+               "key": 1,
+               "metric": {
+                  "metricId": 29,
+                  "arrayIndex": 0,
+                  "deviceId": 0,
+                  "statId": 1,
+                  "desiredUnitId": 0
+               },
+               "lineColor": {
+                  "r": 255,
+                  "g": 129,
+                  "b": 0,
+                  "a": 0.8627450980392157
+               },
+               "fillColor": {
+                  "r": 57,
+                  "g": 210,
+                  "b": 250,
+                  "a": 0.09803921568627451
+               },
+               "axisAffinity": 0
+            },
+            {
+               "key": 5,
+               "metric": {
+                  "metricId": 28,
+                  "arrayIndex": 0,
+                  "deviceId": 0,
+                  "statId": 1,
+                  "desiredUnitId": 0
+               },
+               "lineColor": {
+                  "r": 219,
+                  "g": 219,
+                  "b": 219,
+                  "a": 0.8627450980392157
+               },
+               "fillColor": {
+                  "r": 57,
+                  "g": 210,
+                  "b": 250,
+                  "a": 0.09803921568627451
+               },
+               "axisAffinity": 1
+            }
+         ],
+         "widgetType": 0,
+         "height": 80,
+         "vDivs": 4,
+         "hDivs": 40,
+         "showBottomAxis": false,
+         "graphType": {
+            "name": "Line",
+            "range": [
+               0,
+               150
+            ],
+            "rangeRight": [
+               0,
+               150
+            ],
+            "binCount": 40,
+            "countRange": [
+               0,
+               1000
+            ],
+            "autoLeft": true,
+            "autoRight": true,
+            "autoCount": false
+         },
+         "gridColor": {
+            "r": 47,
+            "g": 120,
+            "b": 190,
+            "a": 0.1568627450980392
          },
          "dividerColor": {
             "r": 57,
@@ -309,20 +515,20 @@
          "textSize": 11
       },
       {
-         "key": 4,
+         "key": 6,
          "metrics": [
             {
-               "key": 11,
+               "key": 4,
                "metric": {
-                  "metricId": 33,
+                  "metricId": 31,
                   "arrayIndex": 0,
                   "deviceId": null,
                   "statId": 1
                },
                "lineColor": {
-                  "r": 0,
-                  "g": 225,
-                  "b": 253,
+                  "r": 186,
+                  "g": 223,
+                  "b": 45,
                   "a": 0.8627450980392157
                },
                "fillColor": {
@@ -332,6 +538,135 @@
                   "a": 0.09803921568627451
                },
                "axisAffinity": 0
+            },
+            {
+               "key": 6,
+               "metric": {
+                  "metricId": 32,
+                  "arrayIndex": 0,
+                  "deviceId": 0,
+                  "statId": 1,
+                  "desiredUnitId": 0
+               },
+               "lineColor": {
+                  "r": 100,
+                  "g": 255,
+                  "b": 255,
+                  "a": 0.8627450980392157
+               },
+               "fillColor": {
+                  "r": 57,
+                  "g": 210,
+                  "b": 250,
+                  "a": 0.09803921568627451
+               },
+               "axisAffinity": 1
+            }
+         ],
+         "widgetType": 0,
+         "height": 80,
+         "vDivs": 4,
+         "hDivs": 40,
+         "showBottomAxis": false,
+         "graphType": {
+            "name": "Line",
+            "range": [
+               100,
+               200
+            ],
+            "rangeRight": [
+               0,
+               150
+            ],
+            "binCount": 40,
+            "countRange": [
+               0,
+               1000
+            ],
+            "autoLeft": true,
+            "autoRight": true,
+            "autoCount": false
+         },
+         "gridColor": {
+            "r": 47,
+            "g": 120,
+            "b": 190,
+            "a": 0.1568627450980392
+         },
+         "dividerColor": {
+            "r": 57,
+            "g": 126,
+            "b": 150,
+            "a": 0.8627450980392157
+         },
+         "backgroundColor": {
+            "r": 0,
+            "g": 0,
+            "b": 0,
+            "a": 0
+         },
+         "borderColor": {
+            "r": 0,
+            "g": 0,
+            "b": 0,
+            "a": 0
+         },
+         "textColor": {
+            "r": 242,
+            "g": 242,
+            "b": 242,
+            "a": 1
+         },
+         "textSize": 11
+      },
+      {
+         "key": 7,
+         "metrics": [
+            {
+               "key": 14,
+               "metric": {
+                  "metricId": 47,
+                  "arrayIndex": 0,
+                  "deviceId": 0,
+                  "statId": 1,
+                  "desiredUnitId": 0
+               },
+               "lineColor": {
+                  "r": 255,
+                  "g": 71,
+                  "b": 0,
+                  "a": 0.8627450980392157
+               },
+               "fillColor": {
+                  "r": 57,
+                  "g": 210,
+                  "b": 250,
+                  "a": 0.09803921568627451
+               },
+               "axisAffinity": 0
+            },
+            {
+               "key": 4,
+               "metric": {
+                  "metricId": 48,
+                  "arrayIndex": 0,
+                  "deviceId": 0,
+                  "statId": 0,
+                  "desiredUnitId": 0
+               },
+               "lineColor": {
+                  "r": 132,
+                  "g": 100,
+                  "b": 255,
+                  "a": 0.8627450980392157
+               },
+               "fillColor": {
+                  "r": 57,
+                  "g": 210,
+                  "b": 250,
+                  "a": 0.09803921568627451
+               },
+               "axisAffinity": 1
             }
          ],
          "widgetType": 0,

--- a/IntelPresentMon/AppCef/ipm-ui-vue/presets/preset-3.json
+++ b/IntelPresentMon/AppCef/ipm-ui-vue/presets/preset-3.json
@@ -8,90 +8,6 @@
          "key": 0,
          "metrics": [
             {
-               "key": 0,
-               "metric": {
-                  "metricId": 0,
-                  "arrayIndex": 0,
-                  "deviceId": null,
-                  "statId": 0
-               },
-               "lineColor": {
-                  "r": 100,
-                  "g": 255,
-                  "b": 255,
-                  "a": 0.8627450980392157
-               },
-               "fillColor": {
-                  "r": 57,
-                  "g": 210,
-                  "b": 250,
-                  "a": 0.09803921568627451
-               },
-               "axisAffinity": 0
-            }
-         ],
-         "widgetType": 1,
-         "showLabel": true,
-         "fontSize": 12,
-         "fontColor": {
-            "r": 205,
-            "g": 211,
-            "b": 233,
-            "a": 1
-         },
-         "backgroundColor": {
-            "r": 45,
-            "g": 50,
-            "b": 96,
-            "a": 0.4
-         }
-      },
-      {
-         "key": 7,
-         "metrics": [
-            {
-               "key": 10,
-               "metric": {
-                  "metricId": 5,
-                  "arrayIndex": 0,
-                  "deviceId": null,
-                  "statId": 0
-               },
-               "lineColor": {
-                  "r": 100,
-                  "g": 255,
-                  "b": 255,
-                  "a": 0.8627450980392157
-               },
-               "fillColor": {
-                  "r": 57,
-                  "g": 210,
-                  "b": 250,
-                  "a": 0.09803921568627451
-               },
-               "axisAffinity": 0
-            }
-         ],
-         "widgetType": 1,
-         "showLabel": false,
-         "fontSize": 12,
-         "fontColor": {
-            "r": 205,
-            "g": 211,
-            "b": 233,
-            "a": 1
-         },
-         "backgroundColor": {
-            "r": 45,
-            "g": 50,
-            "b": 96,
-            "a": 0.4
-         }
-      },
-      {
-         "key": 5,
-         "metrics": [
-            {
                "key": 8,
                "metric": {
                   "metricId": 3,
@@ -116,7 +32,7 @@
          ],
          "widgetType": 1,
          "showLabel": false,
-         "fontSize": 12,
+         "fontSize": 20,
          "fontColor": {
             "r": 205,
             "g": 211,
@@ -131,7 +47,7 @@
          }
       },
       {
-         "key": 2,
+         "key": 1,
          "metrics": [
             {
                "key": 3,
@@ -173,10 +89,10 @@
          }
       },
       {
-         "key": 3,
+         "key": 2,
          "metrics": [
             {
-               "key": 4,
+               "key": 11,
                "metric": {
                   "metricId": 12,
                   "arrayIndex": 0,
@@ -198,29 +114,7 @@
                "axisAffinity": 0
             },
             {
-               "key": 5,
-               "metric": {
-                  "metricId": 12,
-                  "arrayIndex": 0,
-                  "deviceId": null,
-                  "statId": 6
-               },
-               "lineColor": {
-                  "r": 100,
-                  "g": 255,
-                  "b": 255,
-                  "a": 0.8627450980392157
-               },
-               "fillColor": {
-                  "r": 57,
-                  "g": 210,
-                  "b": 250,
-                  "a": 0.09803921568627451
-               },
-               "axisAffinity": 0
-            },
-            {
-               "key": 6,
+               "key": 0,
                "metric": {
                   "metricId": 12,
                   "arrayIndex": 0,
@@ -228,9 +122,9 @@
                   "statId": 5
                },
                "lineColor": {
-                  "r": 255,
-                  "g": 100,
-                  "b": 100,
+                  "r": 19,
+                  "g": 243,
+                  "b": 30,
                   "a": 0.8627450980392157
                },
                "fillColor": {
@@ -271,6 +165,12 @@
             "g": 120,
             "b": 190,
             "a": 0.1568627450980392
+         },
+         "valueTextColor": {
+            "r": 34,
+            "g": 210,
+            "b": 250,
+            "a": 0.8627450980392157
          },
          "dividerColor": {
             "r": 57,
@@ -299,20 +199,20 @@
          "textSize": 11
       },
       {
-         "key": 1,
+         "key": 3,
          "metrics": [
             {
-               "key": 1,
+               "key": 12,
                "metric": {
-                  "metricId": 8,
+                  "metricId": 28,
                   "arrayIndex": 0,
-                  "statId": 1,
-                  "deviceId": null
+                  "deviceId": null,
+                  "statId": 1
                },
                "lineColor": {
-                  "r": 100,
+                  "r": 249,
                   "g": 255,
-                  "b": 255,
+                  "b": 100,
                   "a": 0.8627450980392157
                },
                "fillColor": {
@@ -324,17 +224,17 @@
                "axisAffinity": 0
             },
             {
-               "key": 2,
+               "key": 13,
                "metric": {
-                  "metricId": 14,
+                  "metricId": 31,
                   "arrayIndex": 0,
                   "deviceId": null,
                   "statId": 1
                },
                "lineColor": {
-                  "r": 255,
-                  "g": 243,
-                  "b": 100,
+                  "r": 193,
+                  "g": 174,
+                  "b": 255,
                   "a": 0.8627450980392157
                },
                "fillColor": {
@@ -343,7 +243,7 @@
                   "b": 250,
                   "a": 0.09803921568627451
                },
-               "axisAffinity": 0
+               "axisAffinity": 1
             }
          ],
          "widgetType": 0,
@@ -375,6 +275,12 @@
             "g": 120,
             "b": 190,
             "a": 0.1568627450980392
+         },
+         "valueTextColor": {
+            "r": 34,
+            "g": 210,
+            "b": 250,
+            "a": 0.8627450980392157
          },
          "dividerColor": {
             "r": 57,
@@ -406,17 +312,17 @@
          "key": 4,
          "metrics": [
             {
-               "key": 7,
+               "key": 11,
                "metric": {
-                  "metricId": 64,
+                  "metricId": 33,
                   "arrayIndex": 0,
                   "deviceId": null,
                   "statId": 1
                },
                "lineColor": {
-                  "r": 100,
-                  "g": 255,
-                  "b": 255,
+                  "r": 0,
+                  "g": 225,
+                  "b": 253,
                   "a": 0.8627450980392157
                },
                "fillColor": {
@@ -486,4 +392,3 @@
       }
    ]
 }
-

--- a/IntelPresentMon/AppCef/ipm-ui-vue/src/App.vue
+++ b/IntelPresentMon/AppCef/ipm-ui-vue/src/App.vue
@@ -29,7 +29,7 @@ const notes = useNotificationsStore()
 
 // === Functions ===
 function cyclePreset() {
-  if (prefs.preferences.selectedPreset === null || prefs.preferences.selectedPreset >= 2) {
+  if (prefs.preferences.selectedPreset === null || prefs.preferences.selectedPreset >= 3) {
     prefs.preferences.selectedPreset = 0;
   } else {
     prefs.preferences.selectedPreset++;

--- a/IntelPresentMon/AppCef/ipm-ui-vue/src/core/preferences.ts
+++ b/IntelPresentMon/AppCef/ipm-ui-vue/src/core/preferences.ts
@@ -12,6 +12,7 @@ export enum Preset {
     Slot1 = 0,
     Slot2 = 1,
     Slot3 = 2,
+    Slot4 = 3,
     Custom = 1000,
 }
 

--- a/IntelPresentMon/AppCef/ipm-ui-vue/src/views/MainView.vue
+++ b/IntelPresentMon/AppCef/ipm-ui-vue/src/views/MainView.vue
@@ -179,6 +179,10 @@ const processFromItem = (item: ListItem<unknown>) => item.raw as Process;
             </v-btn>
 
             <v-btn class="px-5" large>
+            Game Experience
+            </v-btn>
+
+            <v-btn class="px-5" large>
             GPU Focus
             </v-btn>
 

--- a/IntelPresentMon/PMInstaller/PresentMon.wxs
+++ b/IntelPresentMon/PMInstaller/PresentMon.wxs
@@ -509,6 +509,16 @@
                     KeyPath="yes">
                 </File>
             </Component>
+            <Component
+                Id="pm_app_preset_3"
+                Guid="A1C2E3F4-5B6D-4789-A012-3456789ABCDE">
+                <File
+                    Id="pm_app_preset_3"
+                    Name="preset-3.json"
+                    Source="$(var.PresentMon.TargetDir)Presets\preset-3.json"
+                    KeyPath="yes">
+                </File>
+            </Component>
         </ComponentGroup>
         <ComponentGroup
             Id="pm_app_web"


### PR DESCRIPTION
Introduce a fourth default loadout (preset-1.json) and reorder shipped presets so indices 0–3 match UI order: Basic, Game Experience, GPU Focus, Power/Temp.